### PR TITLE
scraps page 스크랩 생성 후 리로드 이슈

### DIFF
--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -121,10 +121,10 @@ const ScrapPage: React.FC = () => {
         // 스크랩 목록 새로고침 (약간의 지연 후)
         setTimeout(async () => {
           await loadScraps();
-        }, 1000);
+        }, 300);
         
         // 성공 상태 2초 후 리셋
-        setTimeout(() => setClipStatus('idle'), 2000);
+        setTimeout(() => setClipStatus('idle'), 300);
       } else {
         throw new Error(response.error || 'Clipping failed');
       }
@@ -142,7 +142,7 @@ const ScrapPage: React.FC = () => {
       setClipStatus('error');
       
       // 에러 상태 3초 후 리셋
-      setTimeout(() => setClipStatus('idle'), 3000);
+      setTimeout(() => setClipStatus('idle'), 300);
     } finally {
       setIsClipping(false);
     }


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-108](https://linear.app/chill-mato/issue/CHI-108/us-24-스크랩-불러오기-관련-버그-수정)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
스크랩 버튼 클릭 후, reload 함수 setTimeout 시간 더 짧게
- 2000ms -> 300ms
- setTimeout 간격 줄이기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced the waiting time for UI feedback and scrap list refresh after clipping actions, resulting in a faster and more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->