### PR TITLE
feat: template(글구조) 생성 기능추가

### DIFF
--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -46,6 +46,27 @@ export interface UpdateArticleDto {
 }
 
 /**
+ * 템플릿 구조 분석 DTO
+ */
+export interface AnalyzeContentDto {
+    content: string;
+}
+
+/**
+ * 템플릿 섹션 인터페이스
+ */
+export interface TemplateSection {
+    title: string;
+    description: string;
+    children?: TemplateSection[];
+    id?: string; // 고유 식별자 추가
+}
+
+export interface AnalyzeContentResponse {
+    sections: TemplateSection[];
+}
+
+/**
  * 아티클 생성 응답 타입 (generate API 전용)
  */
 export interface GenerateArticleResponse {
@@ -227,6 +248,17 @@ export class ArticleService {
         return this.apiRequest('/v1/articles/batch', {
             method: 'DELETE',
             body: JSON.stringify(articleIds),
+        });
+    }
+
+    /**
+     * 콘텐츠 분석하여 템플릿 구조 생성
+     * POST /api/v1/articles/analyze-template
+     */
+    async analyzeContentForTemplate(analyzeData: AnalyzeContentDto): Promise<AnalyzeContentResponse> {
+        return await this.apiRequest('/v1/articles/analyze-structure', {
+            method: 'POST',
+            body: JSON.stringify(analyzeData),
         });
     }
 }

--- a/src/sidepanel/pages/ArticleGeneratePage.tsx
+++ b/src/sidepanel/pages/ArticleGeneratePage.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useReducer, useState, useMemo } from 'react';
-import { IoAdd, IoClose, IoSparkles, IoCheckmark } from 'react-icons/io5';
+import { IoAdd, IoClose, IoSparkles, IoCheckmark, IoTrash, IoRemove } from 'react-icons/io5';
 import styles from './PageStyles.module.css';
 import { Scrap, mockTemplates } from '../../mock/data';
 import { TagSelector } from '../components/TagSelector';
 import { TagList } from '../components/TagList';
 import { useToastHelpers } from '../../hooks/useToast';
 import { ScrapResponse, scrapService } from '../../services/scrapService';
-import { articleService, GenerateArticleDto, ScrapWithOptionalComment } from '../../services/articleService';
+import { articleService, GenerateArticleDto, ScrapWithOptionalComment, TemplateSection } from '../../services/articleService';
 
 interface ArticleGeneratePageProps {
   onNavigateToDetail: (articleId: number) => void;
@@ -17,6 +17,8 @@ interface ArticleGeneratePageProps {
 interface SelectedScrap extends ScrapResponse {
   opinion: string;
 }
+
+// Template sections are imported from articleService
 
 interface ArticleGenerateState {
   topic: string;
@@ -30,6 +32,12 @@ interface ArticleGenerateState {
   isGenerating: boolean;
   generationError: string | null;
   generationStatus: 'idle' | 'success' | 'error';
+  // New state properties
+  templateStructure: TemplateSection[] | null;
+  structuredIdeas: Record<string, string>;
+  templateTitles: Record<string, string>; // 편집된 템플릿 제목들 (sectionId 기반)
+  sectionIdCounter: number; // 고유 ID 생성용 카운터
+  isAnalyzing: boolean;
 }
 
 type DraftAction =
@@ -47,23 +55,43 @@ type DraftAction =
   | { type: 'TOGGLE_TAG_DROPDOWN' }
   | { type: 'SET_GENERATING'; payload: boolean }
   | { type: 'SET_GENERATION_ERROR'; payload: string | null }
-  | { type: 'SET_GENERATION_STATUS'; payload: 'idle' | 'success' | 'error' };
+  | { type: 'SET_GENERATION_STATUS'; payload: 'idle' | 'success' | 'error' }
+  // New actions
+  | { type: 'SET_ANALYZING'; payload: boolean }
+  | { type: 'SET_TEMPLATE_STRUCTURE'; payload: TemplateSection[] | null }
+  | { type: 'SET_STRUCTURED_IDEA'; payload: { sectionId: string; idea: string } }
+  | { type: 'SET_TEMPLATE_TITLE'; payload: { sectionId: string; newTitle: string } }
+  | { type: 'ADD_TEMPLATE_SECTION'; payload: { parentId?: string; title: string } }
+  | { type: 'REMOVE_TEMPLATE_SECTION'; payload: string }
+  | { type: 'CLEAR_TEMPLATE' };
 
 const STORAGE_KEY = 'tyquill-article-generate-draft';
 
 const getInitialState = (): ArticleGenerateState => {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
+    console.log('🔍 Loading saved state:', saved);
     if (saved) {
       const parsedState = JSON.parse(saved);
-      return {
+      console.log('🔍 Parsed state:', parsedState);
+      console.log('🔍 Template structure from storage:', parsedState.templateStructure);
+      
+      const restoredState = {
         ...parsedState,
         isScrapModalOpen: false,
         isTagDropdownOpen: false,
         isGenerating: false,
         generationError: null,
         generationStatus: 'idle',
+        templateStructure: parsedState.templateStructure || null, // 템플릿 구조도 복원
+        structuredIdeas: parsedState.structuredIdeas || {},
+        templateTitles: parsedState.templateTitles || {},
+        sectionIdCounter: parsedState.sectionIdCounter || 0,
+        isAnalyzing: false,
       };
+      
+      console.log('✅ Restored state with template:', restoredState.templateStructure);
+      return restoredState;
     }
   } catch (error) {
     console.warn('Failed to load saved draft state:', error);
@@ -81,6 +109,11 @@ const getInitialState = (): ArticleGenerateState => {
     isGenerating: false,
     generationError: null,
     generationStatus: 'idle',
+    templateStructure: null, // 기본값은 null
+    structuredIdeas: {},
+    templateTitles: {},
+    sectionIdCounter: 0,
+    isAnalyzing: false,
   };
 };
 
@@ -137,6 +170,116 @@ function draftReducer(state: ArticleGenerateState, action: DraftAction): Article
       return { ...state, generationError: action.payload };
     case 'SET_GENERATION_STATUS':
       return { ...state, generationStatus: action.payload };
+    // New reducers
+    case 'SET_ANALYZING':
+      return { ...state, isAnalyzing: action.payload };
+    case 'SET_TEMPLATE_STRUCTURE':
+      // AI로 생성된 섹션에도 고유 ID 부여 및 기본 제목 저장
+      let counter = state.sectionIdCounter;
+      const initialTitles: Record<string, string> = {};
+      
+      const assignIds = (sections: TemplateSection[]): TemplateSection[] => {
+        return sections.map(section => {
+          const sectionId = section.id || `section_${counter++}`;
+          initialTitles[sectionId] = section.title; // 기본 제목 저장
+          return {
+            ...section,
+            id: sectionId,
+            children: section.children ? assignIds(section.children) : []
+          };
+        });
+      };
+      
+      const sectionsWithIds = action.payload ? assignIds(action.payload) : null;
+      
+      return { 
+        ...state, 
+        templateStructure: sectionsWithIds, 
+        structuredIdeas: {}, 
+        templateTitles: initialTitles, // AI 섹션들의 기본 제목 저장
+        sectionIdCounter: counter
+      };
+    case 'SET_STRUCTURED_IDEA':
+      return { ...state, structuredIdeas: { ...state.structuredIdeas, [action.payload.sectionId]: action.payload.idea } };
+    case 'SET_TEMPLATE_TITLE':
+      return { ...state, templateTitles: { ...state.templateTitles, [action.payload.sectionId]: action.payload.newTitle } };
+    case 'ADD_TEMPLATE_SECTION':
+      const newSectionId = `section_${state.sectionIdCounter}`;
+      const newSection: TemplateSection = {
+        title: action.payload.title,
+        description: '',
+        children: [],
+        id: newSectionId
+      };
+      
+      if (!action.payload.parentId) {
+        // 최상위 섹션 추가 (templateStructure가 null이면 새 배열 생성)
+        return {
+          ...state,
+          templateStructure: state.templateStructure ? [...state.templateStructure, newSection] : [newSection],
+          templateTitles: { ...state.templateTitles, [newSectionId]: action.payload.title }, // 기본 제목 저장
+          sectionIdCounter: state.sectionIdCounter + 1
+        };
+      } else {
+        // 하위 섹션 추가 - templateStructure가 없으면 스킵
+        if (!state.templateStructure) return state;
+        
+        const addChildToSection = (sections: TemplateSection[]): TemplateSection[] => {
+          return sections.map((section) => {
+            if (section.id === action.payload.parentId) {
+              return {
+                ...section,
+                children: [...(section.children || []), newSection]
+              };
+            }
+            if (section.children && section.children.length > 0) {
+              return {
+                ...section,
+                children: addChildToSection(section.children)
+              };
+            }
+            return section;
+          });
+        };
+        
+        return {
+          ...state,
+          templateStructure: addChildToSection(state.templateStructure),
+          templateTitles: { ...state.templateTitles, [newSectionId]: action.payload.title }, // 기본 제목 저장
+          sectionIdCounter: state.sectionIdCounter + 1
+        };
+      }
+    case 'REMOVE_TEMPLATE_SECTION':
+      if (!state.templateStructure) return state;
+      
+      const removeSectionById = (sections: TemplateSection[], targetId: string): TemplateSection[] => {
+        return sections.filter((section) => {
+          if (section.id === targetId) {
+            return false; // 이 섹션 제거
+          }
+          
+          if (section.children && section.children.length > 0) {
+            section.children = removeSectionById(section.children, targetId);
+          }
+          
+          return true;
+        });
+      };
+      
+      // 삭제된 섹션의 데이터도 제거
+      const updatedStructuredIdeas = { ...state.structuredIdeas };
+      const updatedTemplateTitles = { ...state.templateTitles };
+      delete updatedStructuredIdeas[action.payload];
+      delete updatedTemplateTitles[action.payload];
+      
+      return {
+        ...state,
+        templateStructure: removeSectionById(state.templateStructure, action.payload),
+        structuredIdeas: updatedStructuredIdeas,
+        templateTitles: updatedTemplateTitles
+      };
+    case 'CLEAR_TEMPLATE':
+      return { ...state, templateStructure: null, structuredIdeas: {}, templateTitles: {} };
     default:
       return state;
   }
@@ -149,9 +292,14 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
 }) => {
   const { showSuccess, showError, showInfo } = useToastHelpers();
   const [state, dispatch] = useReducer(draftReducer, getInitialState());
+  
+  // 디버깅: 템플릿 구조 상태 변화 추적
+  useEffect(() => {
+    console.log('📊 Current template structure:', state.templateStructure);
+  }, [state.templateStructure]);
   const [showAllTags, setShowAllTags] = useState<string | null>(null);
 
-  // Save state to localStorage whenever relevant state changes
+  // Save state to localStorage whenever relevant state changes (템플릿 포함)
   useEffect(() => {
     const stateToSave = {
       topic: state.topic,
@@ -160,6 +308,11 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
       selectedTemplate: state.selectedTemplate,
       selectedScraps: state.selectedScraps,
       selectedTags: state.selectedTags,
+      // 템플릿 관련 상태들도 저장
+      templateStructure: state.templateStructure,
+      structuredIdeas: state.structuredIdeas,
+      templateTitles: state.templateTitles,
+      sectionIdCounter: state.sectionIdCounter,
     };
     
     try {
@@ -167,7 +320,18 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
     } catch (error) {
       console.warn('Failed to save draft state:', error);
     }
-  }, [state.topic, state.keyInsight, state.handle, state.selectedTemplate, state.selectedScraps, state.selectedTags]);
+  }, [
+    state.topic, 
+    state.keyInsight, 
+    state.handle, 
+    state.selectedTemplate, 
+    state.selectedScraps, 
+    state.selectedTags,
+    state.templateStructure,
+    state.structuredIdeas,
+    state.templateTitles,
+    state.sectionIdCounter
+  ]);
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -198,14 +362,11 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
   }, [showAllTags, state.isScrapModalOpen]);
 
   const handleScrapSelect = (scrap: ScrapResponse) => {
-    // 이미 선택된 스크랩인지 확인
     const isSelected = state.selectedScraps.find(s => s.scrapId === scrap.scrapId);
     
     if (isSelected) {
-      // 이미 선택된 경우 선택 해제
       dispatch({ type: 'REMOVE_SCRAP', payload: scrap.scrapId });
     } else {
-      // 선택되지 않은 경우 추가
       dispatch({ type: 'ADD_SCRAP', payload: scrap });
     }
   };
@@ -218,11 +379,126 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
     dispatch({ type: 'REMOVE_SCRAP', payload: id });
   };
 
+  const handleGenerateTemplateFromPage = async () => {
+    if (state.isAnalyzing) return;
+
+    try {
+      dispatch({ type: 'SET_ANALYZING', payload: true });
+      
+      // 현재 활성 탭 정보 가져오기
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      
+      if (!tab?.id) {
+        throw new Error('활성 탭을 찾을 수 없습니다.');
+      }
+
+      // URL 체크 - 제한된 페이지에서는 스크랩 불가
+      if (tab.url?.startsWith('chrome://') || 
+          tab.url?.startsWith('chrome-extension://') ||
+          tab.url?.startsWith('edge://') ||
+          tab.url?.startsWith('about:')) {
+        throw new Error('이 페이지에서는 스크랩할 수 없습니다. (chrome://, extension:// 등 제한된 페이지)');
+      }
+
+      // Content Script가 로드되었는지 확인
+      try {
+        await chrome.tabs.sendMessage(tab.id, { type: 'PING' });
+      } catch (pingError) {
+        // Content script 수동 주입 시도
+        await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ['contentScript/index.js']
+        });
+        
+        // 잠시 대기 후 재시도
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+
+      showInfo('페이지 분석 중...', '현재 페이지의 구조를 분석하여 템플릿을 생성하고 있습니다.');
+
+      // 페이지 콘텐츠 스크랩
+      const response = await chrome.tabs.sendMessage(tab.id, {
+        type: 'CLIP_PAGE',
+        options: { includeMetadata: false }
+      });
+
+      if (!response.success) {
+        throw new Error(response.error || '페이지 콘텐츠를 가져오는데 실패했습니다.');
+      }
+
+      // 서버에 콘텐츠 분석 요청
+      const templateSections = await articleService.analyzeContentForTemplate({
+        content: response.data.content,
+      });
+
+      const sections = templateSections.sections
+
+      console.log(sections);
+
+      if (!sections || !Array.isArray(sections) || sections.length === 0) {
+        throw new Error('페이지 구조를 분석할 수 없습니다.');
+      }
+
+      dispatch({ type: 'SET_TEMPLATE_STRUCTURE', payload: sections });
+      showSuccess('섹션 구성 완료', `${sections.length}개의 섹션으로 구성을 만들었습니다.`);
+
+    } catch (error: any) {
+      console.error('Template generation error:', error);
+      showError('섹션 구성 실패', error.message || '섹션 구성 생성 중 오류가 발생했습니다.');
+    } finally {
+      dispatch({ type: 'SET_ANALYZING', payload: false });
+    }
+  };
+
+  const handleIdeaChange = (sectionId: string, idea: string) => {
+    dispatch({ type: 'SET_STRUCTURED_IDEA', payload: { sectionId, idea } });
+  };
+
+  const handleTitleChange = (sectionId: string, newTitle: string) => {
+    dispatch({ type: 'SET_TEMPLATE_TITLE', payload: { sectionId, newTitle } });
+  };
+
+  const addSection = (parentId?: string) => {
+    const newTitle = parentId ? '새 하위 섹션' : '새 섹션';
+    console.log('🔥 Adding section:', { parentId, title: newTitle });
+    console.log('🔥 Current template structure before:', state.templateStructure);
+    dispatch({ type: 'ADD_TEMPLATE_SECTION', payload: { parentId, title: newTitle } });
+  };
+
+  const removeSection = (sectionId: string) => {
+    dispatch({ type: 'REMOVE_TEMPLATE_SECTION', payload: sectionId });
+  };
+
+  // 섹션 구조를 평탄화하여 렌더링하는 함수 (ID 기반)
+  const flattenSections = (sections: TemplateSection[], level = 0, parentId?: string): Array<{ section: TemplateSection; level: number; id: string; parentId?: string }> => {
+    const result: Array<{ section: TemplateSection; level: number; id: string; parentId?: string }> = [];
+    
+    sections.forEach((section) => {
+      const sectionId = section.id!; // 이제 고유 ID 사용
+      result.push({ section, level, id: sectionId, parentId });
+      
+      if (section.children && section.children.length > 0) {
+        result.push(...flattenSections(section.children, level + 1, sectionId));
+      }
+    });
+    
+    return result;
+  };
+
   const handleGenerateArticle = async () => {
-    if (!state.topic || !state.keyInsight) {
-      dispatch({ type: 'SET_GENERATION_ERROR', payload: '주제와 키메시지를 입력해주세요.' });
-      showError('입력 오류', '주제와 키메시지를 모두 입력해주세요.');
-      return;
+    const isTemplateMode = state.templateStructure && Object.values(state.structuredIdeas).some(idea => idea.trim() !== '');
+
+    if (isTemplateMode) {
+      if (!Object.values(state.structuredIdeas).some(idea => idea.trim() !== '')) {
+        showError('입력 오류', '섹션의 아이디어를 하나 이상 입력해주세요.');
+        return;
+      }
+    } else {
+      if (!state.topic || !state.keyInsight) {
+        dispatch({ type: 'SET_GENERATION_ERROR', payload: '주제와 키메시지를 입력해주세요.' });
+        showError('입력 오류', '주제와 키메시지를 모두 입력해주세요.');
+        return;
+      }
     }
 
     if (state.isGenerating) return;
@@ -232,9 +508,10 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
       dispatch({ type: 'SET_GENERATION_ERROR', payload: null });
       dispatch({ type: 'SET_GENERATION_STATUS', payload: 'idle' });
 
+      // TODO: Update GenerateArticleDto to include template structure and ideas
       const generateData: GenerateArticleDto = {
-        topic: state.topic,
-        keyInsight: state.keyInsight,
+        topic: isTemplateMode ? (state.templateStructure?.[0]?.title || '섹션 기반 아티클') : state.topic,
+        keyInsight: isTemplateMode ? JSON.stringify(state.structuredIdeas) : state.keyInsight,
         scrapWithOptionalComment: state.selectedScraps.map(scrap => ({
           scrapId: scrap.scrapId,
           userComment: scrap.opinion || undefined,
@@ -242,36 +519,29 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
         generationParams: state.handle || undefined,
       };
 
-      // 요청 보내기
       articleService.generateArticle(generateData)
         .then(result => {
-          showSuccess('초안 생성 완료', '초안 생성이 완료되었습니다. 보관함에서 생성된 초안을 확인해 보세요!');
-          // ArchivePage에서 목록 새로고침
+          showSuccess('초안 생성 완료', '보관함에서 생성된 초안을 확인해 보세요!');
           if (currentPage === 'archive' && onRefreshArchiveList) {
             onRefreshArchiveList();
           }
         })
         .catch(error => {
-          showError(
-            '초안 생성 실패',
-            error.message || '초안 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
-          );
+          showError('초안 생성 실패', error.message || '초안 생성 중 오류가 발생했습니다.');
         });
 
-      // 요청을 보낸 직후 성공 상태로 변경
       dispatch({ type: 'SET_GENERATION_STATUS', payload: 'success' });
       showInfo('초안 생성 요청 전송', '초안 생성 요청을 보냈습니다. (예상 대기 시간: 2분)');
       
-      // 2초 후 상태 초기화
       setTimeout(() => {
         dispatch({ type: 'SET_GENERATION_STATUS', payload: 'idle' });
       }, 2000);
 
-      // 초기 상태로 리셋 및 localStorage 클리어
       dispatch({ type: 'SET_SUBJECT', payload: '' });
       dispatch({ type: 'SET_MESSAGE', payload: '' });
       dispatch({ type: 'SET_HANDLE', payload: '' });
       dispatch({ type: 'CLEAR_SCRAPS' });
+      dispatch({ type: 'CLEAR_TEMPLATE' });
       
       try {
         localStorage.removeItem(STORAGE_KEY);
@@ -280,15 +550,10 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
       }
 
     } catch (error: any) {
-      // 요청 자체가 실패한 경우 (네트워크 오류 등)
       dispatch({ type: 'SET_GENERATION_ERROR', payload: error.message || '초안 생성에 실패했습니다.' });
       dispatch({ type: 'SET_GENERATION_STATUS', payload: 'error' });
-      showError(
-        '요청 전송 실패',
-        error.message || '요청을 보내는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
-      );
+      showError('요청 전송 실패', error.message || '요청을 보내는 중 오류가 발생했습니다.');
       
-      // 3초 후 에러 상태 초기화
       setTimeout(() => {
         dispatch({ type: 'SET_GENERATION_STATUS', payload: 'idle' });
       }, 3000);
@@ -296,9 +561,6 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
       dispatch({ type: 'SET_GENERATING', payload: false });
     }
   };
-
-
-
 
   const [allScraps, setAllScraps] = useState<ScrapResponse[]>([]);
   const [allTags, setAllTags] = useState<string[]>([]);
@@ -312,21 +574,18 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
     fetchScraps();
   }, []);
 
-  // 선택된 태그에 따라 필터링된 스크랩 목록
   const filteredScraps = useMemo(() => {
     if (state.selectedTags.length === 0) {
-      return allScraps; // 선택된 태그가 없으면 모든 스크랩 표시
+      return allScraps;
     }
     
     return allScraps.filter(scrap => {
-      // 선택된 태그 중 하나라도 스크랩에 포함되어 있으면 표시
       return state.selectedTags.some(selectedTag => 
         scrap.tags?.some(tag => tag.name === selectedTag)
       );
     });
   }, [allScraps, state.selectedTags]);
 
-  // 날짜 포맷팅 함수
   const formatScrapDate = (dateString: string) => {
     try {
       const date = new Date(dateString);
@@ -338,7 +597,7 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
       
       return `${year}. ${month}. ${day}. ${hours}:${minutes}`;
     } catch (error) {
-      return dateString; // 파싱 실패시 원본 반환
+      return dateString;
     }
   };
 
@@ -377,7 +636,6 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
               rows={4}
             />
           </div>
-
           {/* <div className={styles.formGroup}>
             <label htmlFor="handle" className={styles.formLabel}>
               maily 핸들
@@ -412,15 +670,355 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
             </select>
           </div> */}
 
+          {/* 섹션 구성 */}
           <div className={styles.referenceSection}>
-            <h3 className={styles.sectionTitle}>참고 자료 선택</h3>
+            <div style={{ 
+              display: 'flex', 
+              justifyContent: 'space-between', 
+              alignItems: 'center',
+              marginBottom: '16px'
+            }}>
+              <h3 className={styles.sectionTitle}>섹션 구성</h3>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button 
+                  onClick={() => addSection()}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    padding: '8px 12px',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '6px',
+                    backgroundColor: '#ffffff',
+                    color: '#374151',
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    fontWeight: '500',
+                    transition: 'all 0.2s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = '#f8fafc';
+                    e.currentTarget.style.borderColor = '#d1d5db';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = '#ffffff';
+                    e.currentTarget.style.borderColor = '#e2e8f0';
+                  }}
+                >
+                  <IoAdd size={14} />
+                  섹션 추가
+                </button>
+                
+                <button 
+                  onClick={handleGenerateTemplateFromPage}
+                  disabled={state.isAnalyzing}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    padding: '8px 12px',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '6px',
+                    backgroundColor: state.isAnalyzing ? '#f1f5f9' : 'white',
+                    color: state.isAnalyzing ? '#64748b' : '#374151',
+                    cursor: state.isAnalyzing ? 'not-allowed' : 'pointer',
+                    fontSize: '14px',
+                    fontWeight: '500',
+                    transition: 'all 0.2s',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!state.isAnalyzing) {
+                      e.currentTarget.style.backgroundColor = '#f8fafc';
+                      e.currentTarget.style.borderColor = '#d1d5db';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!state.isAnalyzing) {
+                      e.currentTarget.style.backgroundColor = 'white';
+                      e.currentTarget.style.borderColor = '#e2e8f0';
+                    }
+                  }}
+                  title="현재 페이지를 분석하여 자동으로 섹션 구성을 생성합니다"
+                >
+                  <IoSparkles size={14} />
+                  {state.isAnalyzing ? '분석 중...' : 'AI 분석'}
+                </button>
+              </div>
+            </div>
+            
+            {!state.templateStructure && (
+              <div style={{
+                padding: '24px',
+                backgroundColor: '#f8fafc',
+                borderRadius: '8px',
+                border: '2px dashed #cbd5e1',
+                textAlign: 'center',
+                color: '#64748b',
+                marginBottom: '20px'
+              }}>
+                <IoSparkles size={24} style={{ marginBottom: '8px', opacity: 0.5 }} />
+                <p style={{ margin: '0 0 8px 0', fontSize: '15px', fontWeight: '500' }}>
+                  섹션별로 구성해서 더 체계적인 글을 써보세요
+                </p>
+                <p style={{ margin: '0', fontSize: '13px', opacity: 0.8 }}>
+                  "섹션 추가" 또는 "AI 분석"으로 시작해보세요
+                </p>
+              </div>
+            )}
+
+            {/* 섹션 구성 표시 */}
+            {state.templateStructure && (
+              <div style={{ 
+                marginTop: '20px', 
+                padding: '20px', 
+                backgroundColor: '#f8fafc', 
+                borderRadius: '12px', 
+                border: '1px solid #e2e8f0' 
+              }}>
+                <div style={{ 
+                  display: 'flex', 
+                  justifyContent: 'space-between', 
+                  alignItems: 'center', 
+                  marginBottom: '20px' 
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    <h4 style={{ 
+                      fontSize: '16px', 
+                      fontWeight: '600', 
+                      color: '#1e293b',
+                      margin: '0',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px'
+                    }}>
+                      <IoSparkles size={18} style={{ color: '#3b82f6' }} />
+                      섹션 구성
+                    </h4>
+                    <span style={{
+                      fontSize: '12px',
+                      color: '#10b981',
+                      backgroundColor: '#d1fae5',
+                      padding: '2px 8px',
+                      borderRadius: '12px',
+                      fontWeight: '500'
+                    }}>
+                      자동 저장됨
+                    </span>
+                  </div>
+                  <button 
+                    onClick={() => dispatch({ type: 'CLEAR_TEMPLATE' })}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#64748b',
+                      cursor: 'pointer',
+                      fontSize: '14px',
+                      padding: '4px 8px',
+                      borderRadius: '6px',
+                      transition: 'all 0.2s',
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.backgroundColor = '#e2e8f0';
+                      e.currentTarget.style.color = '#475569';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                      e.currentTarget.style.color = '#64748b';
+                    }}
+                  >
+                    × 초기화
+                  </button>
+                </div>
+                {flattenSections(state.templateStructure).map(({ section, level, id, parentId }) => {
+                  // 제목이 한 번이라도 편집되었다면 templateTitles의 값을 사용 (빈 문자열 포함)
+                  const hasBeenEdited = section.id! in state.templateTitles;
+                  const currentTitle = hasBeenEdited ? state.templateTitles[section.id!] : section.title;
+                  const isChild = level > 0;
+                  
+                  return (
+                    <div key={id} style={{
+                      marginBottom: '16px',
+                      marginLeft: isChild ? '24px' : '0',
+                      padding: '16px',
+                      backgroundColor: isChild ? '#f8fafc' : 'white',
+                      borderRadius: '8px',
+                      border: `1px solid ${isChild ? '#cbd5e1' : '#e2e8f0'}`,
+                      borderLeft: isChild ? '4px solid #3b82f6' : '1px solid #e2e8f0'
+                    }}>
+                      {/* 섹션 헤더 */}
+                      <div style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        marginBottom: '12px'
+                      }}>
+                        <div style={{ flex: 1 }}>
+                          <input
+                            type="text"
+                            value={currentTitle || ''} // 빈 문자열도 허용
+                            onChange={(e) => {
+                              handleTitleChange(section.id!, e.target.value);
+                            }}
+                            style={{
+                              width: '100%',
+                              fontSize: isChild ? '14px' : '15px',
+                              fontWeight: isChild ? '400' : '500',
+                              color: '#1e293b',
+                              border: '1px solid #e2e8f0',
+                              borderRadius: '6px',
+                              padding: '8px 12px',
+                              backgroundColor: isChild ? 'white' : '#f8fafc',
+                              transition: 'all 0.2s',
+                            }}
+                            onFocus={(e) => {
+                              e.target.style.backgroundColor = 'white';
+                              e.target.style.borderColor = '#3b82f6';
+                              e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+                            }}
+                            onBlur={(e) => {
+                              e.target.style.backgroundColor = isChild ? 'white' : '#f8fafc';
+                              e.target.style.borderColor = '#e2e8f0';
+                              e.target.style.boxShadow = 'none';
+                            }}
+                          />
+                        </div>
+                        
+                        {/* 액션 버튼들 */}
+                        <div style={{ display: 'flex', gap: '4px' }}>
+                          {!isChild && (
+                            <button
+                              onClick={() => addSection(id)}
+                              title="하위 섹션 추가"
+                              style={{
+                                padding: '6px',
+                                border: 'none',
+                                borderRadius: '4px',
+                                backgroundColor: '#e0f2fe',
+                                color: '#0369a1',
+                                cursor: 'pointer',
+                                transition: 'all 0.2s',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center'
+                              }}
+                              onMouseEnter={(e) => {
+                                e.currentTarget.style.backgroundColor = '#bae6fd';
+                              }}
+                              onMouseLeave={(e) => {
+                                e.currentTarget.style.backgroundColor = '#e0f2fe';
+                              }}
+                            >
+                              <IoAdd size={14} />
+                            </button>
+                          )}
+                          
+                          <button
+                            onClick={() => removeSection(id)}
+                            title="섹션 삭제"
+                            style={{
+                              padding: '6px',
+                              border: 'none',
+                              borderRadius: '4px',
+                              backgroundColor: '#fee2e2',
+                              color: '#dc2626',
+                              cursor: 'pointer',
+                              transition: 'all 0.2s',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center'
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.backgroundColor = '#fecaca';
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.backgroundColor = '#fee2e2';
+                            }}
+                          >
+                            <IoTrash size={14} />
+                          </button>
+                        </div>
+                      </div>
+                      
+                      {/* 아이디어 입력 필드 */}
+                      <textarea
+                        value={state.structuredIdeas[section.id!] || ''}
+                        onChange={(e) => handleIdeaChange(section.id!, e.target.value)}
+                        rows={3}
+                        style={{
+                          width: '100%',
+                          minHeight: '80px',
+                          fontSize: '14px',
+                          lineHeight: '1.5',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: '6px',
+                          padding: '12px',
+                          backgroundColor: 'white',
+                          resize: 'vertical',
+                          transition: 'all 0.2s',
+                        }}
+                        onFocus={(e) => {
+                          e.target.style.borderColor = '#3b82f6';
+                          e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+                        }}
+                        onBlur={(e) => {
+                          e.target.style.borderColor = '#e2e8f0';
+                          e.target.style.boxShadow = 'none';
+                        }}
+                      />
+                    </div>
+                  );
+                })}
+                
+                {/* 새 섹션 추가 버튼 */}
+                <button
+                  onClick={() => addSection()}
+                  style={{
+                    width: '100%',
+                    padding: '12px',
+                    border: '2px dashed #cbd5e1',
+                    borderRadius: '8px',
+                    backgroundColor: 'transparent',
+                    color: '#64748b',
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    fontWeight: '500',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px',
+                    transition: 'all 0.2s',
+                    marginTop: '16px'
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.borderColor = '#3b82f6';
+                    e.currentTarget.style.color = '#3b82f6';
+                    e.currentTarget.style.backgroundColor = '#f8fafc';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.borderColor = '#cbd5e1';
+                    e.currentTarget.style.color = '#64748b';
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                  }}
+                >
+                  <IoAdd size={16} />
+                  섹션 추가
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* 참고 자료 */}
+          <div className={styles.referenceSection}>
+            <h3 className={styles.sectionTitle}>참고 자료</h3>
             <button 
               className={styles.addReferenceButton}
               onClick={() => dispatch({ type: 'TOGGLE_SCRAP_MODAL' })}
+              style={{ width: '100%', marginBottom: '16px' }}
             >
               <IoAdd size={16} />
               스크랩에서 자료 추가
             </button>
+            
             <div className={styles.referenceList}>
               {state.selectedScraps.map(scrap => (
                 <div key={scrap.scrapId} className={styles.referenceItem}>
@@ -455,7 +1053,7 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
             <button 
               className={`${styles.addButton} ${state.isGenerating ? styles.loading : ''}`}
               onClick={handleGenerateArticle}
-              disabled={state.isGenerating || !state.topic || !state.keyInsight}
+              disabled={state.isGenerating || (!state.topic && !state.templateStructure)}
             >
               {state.generationStatus === 'success' ? (
                 <>
@@ -533,4 +1131,4 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
   );
 };
 
-export default ArticleGeneratePage; 
+export default ArticleGeneratePage;


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-128](https://linear.app/chill-mato/issue/CHI-128)
Closes: [CHI-120](https://linear.app/chill-mato/issue/CHI-120)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 현재 페이지의 글 구조를 ai가 분석 후 섹션으로 변경
- 유저가 섹션 추가/삭제 가능

## 추가사항
- ui 추가적인 개선 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a hierarchical section template system for article generation, allowing users to add, edit, nest, and remove sections with custom titles and ideas.
  * Added AI-powered analysis to automatically generate a section template from the current page content.
  * Enhanced UI with a dedicated panel for managing section structures, including visual indentation, editable fields, and quick section management actions.

* **Improvements**
  * Article drafts now persist and restore template structures and ideas across sessions.
  * Article generation supports both traditional and template-based input modes, with validation for required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->