### PR TITLE
feat: template 글구조 기반 글생성 api 조정

### DIFF
--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -33,6 +33,7 @@ export interface GenerateArticleDto {
     keyInsight: string;
     scrapWithOptionalComment?: ScrapWithOptionalComment[];
     generationParams?: string;
+    articleStructureTemplate?: TemplateSection[];
 }
 
 /**
@@ -57,8 +58,9 @@ export interface AnalyzeContentDto {
  */
 export interface TemplateSection {
     title: string;
-    description: string;
+    keyIdea: string;
     children?: TemplateSection[];
+    
     id?: string; // 고유 식별자 추가
 }
 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-128](https://linear.app/chill-mato/issue/CHI-128/)

## 📋 변경사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
글구조 기반 템플릿으로 글 생성 기능 추가로 인한 api 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved article template customization by allowing users to define section titles and key ideas directly within each section of the template structure.

* **Refactor**
  * Simplified template management by consolidating section titles and ideas into the template structure, removing separate state tracking for these fields.
  * Streamlined state saving and loading, making template editing and persistence more intuitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->