### PR TITLE
[CHI-232] 확장성을 위한 클립보드 복사 기능 추가

### DIFF
--- a/src/components/sidepanel/CopyButton/CopyButton.module.css
+++ b/src/components/sidepanel/CopyButton/CopyButton.module.css
@@ -1,0 +1,49 @@
+.copyButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background-color: transparent;
+  color: #666;
+  border: 1px solid #e1e5e9;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+}
+
+.copyButton:hover {
+  background-color: #f8f9fa;
+  color: #333;
+  border-color: #d1d5db;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.copyButton:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.copyButton:focus {
+  outline: none;
+  border-color: #333;
+  box-shadow: 0 0 0 2px rgba(51, 51, 51, 0.1);
+}
+
+.copyButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.copyButton:disabled:hover {
+  background-color: transparent;
+  color: #666;
+  transform: none;
+  box-shadow: none;
+}
+
+.loadingIcon {
+  opacity: 0.7;
+}

--- a/src/components/sidepanel/CopyButton/CopyButton.tsx
+++ b/src/components/sidepanel/CopyButton/CopyButton.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import { IoClipboard, IoCheckmark } from 'react-icons/io5';
+import { motion, AnimatePresence } from 'framer-motion';
+import styles from './CopyButton.module.css';
+import { useToastHelpers } from '../../../hooks/useToast';
+import { htmlToMarkdown } from '../../../utils/markdownConverter';
+import { animations, getAnimation } from '../../../utils/animations';
+
+interface CopyButtonProps {
+  title: string;
+  content: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({ title, content }) => {
+  const { showSuccess, showError } = useToastHelpers();
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccessAnimation, setShowSuccessAnimation] = useState(false);
+
+  // HTML 태그가 포함되어 있는지 확인하는 함수
+  const containsHtmlTags = (text: string): boolean => {
+    const htmlTagRegex = /<\/?[a-z][\s\S]*>/i;
+    return htmlTagRegex.test(text);
+  };
+
+  // 연속된 개행 문자를 정리하는 함수
+  const normalizeNewlines = (text: string): string => {
+    return text.replace(/\n{3,}/g, '\n\n').trim();
+  };
+
+  const handleCopy = async () => {
+    if (!title.trim() || !content.trim()) {
+      showError('복사 실패', '제목과 내용이 모두 있어야 복사할 수 있습니다.');
+      return;
+    }
+
+    setIsLoading(true);
+    
+    try {
+      // 화면에 렌더링된 콘텐츠 요소를 찾기
+      const contentDisplay = document.querySelector('.contentDisplay, [class*="contentDisplay"]');
+      
+      if (contentDisplay) {
+        // 제목 HTML 생성
+        const titleHtml = `<h1>${title}</h1>`;
+        
+        // 렌더링된 HTML 콘텐츠와 플레인 텍스트 모두 포함
+        const htmlContent = titleHtml + contentDisplay.innerHTML;
+        const textContent = title + '\n\n' + (contentDisplay.textContent || (contentDisplay as HTMLElement).innerText || '');
+        
+        // HTML과 텍스트 모두 클립보드에 저장 (rich text paste 지원)
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([htmlContent], { type: 'text/html' }),
+            'text/plain': new Blob([textContent], { type: 'text/plain' })
+          })
+        ]);
+        
+        showSuccess('복사 완료', '서식이 포함된 형태로 클립보드에 복사되었습니다.');
+        
+        // Show success animation
+        setShowSuccessAnimation(true);
+        setTimeout(() => setShowSuccessAnimation(false), 1500);
+      } else {
+        // 렌더링된 요소를 찾을 수 없는 경우 원본 콘텐츠 복사
+        let cleanContent = content;
+        
+        // HTML 태그가 포함된 경우 마크다운으로 변환
+        if (containsHtmlTags(content)) {
+          cleanContent = htmlToMarkdown(content);
+        }
+        
+        // 연속된 개행 정리
+        cleanContent = normalizeNewlines(cleanContent);
+        
+        // 제목과 내용을 마크다운 형식으로 결합
+        const fullContent = `# ${title}\n\n${cleanContent}`;
+        
+        await navigator.clipboard.writeText(fullContent);
+        showSuccess('복사 완료', '마크다운 형식으로 클립보드에 복사되었습니다.');
+        
+        // Show success animation
+        setShowSuccessAnimation(true);
+        setTimeout(() => setShowSuccessAnimation(false), 1500);
+      }
+    } catch (error) {
+      console.error('Copy error:', error);
+      showError('복사 실패', '클립보드 복사 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <motion.button 
+      className={styles.copyButton}
+      onClick={handleCopy}
+      title="클립보드에 복사"
+      disabled={isLoading}
+      {...getAnimation({
+        whileHover: animations.buttonHover,
+        whileTap: animations.buttonTap
+      })}
+      animate={showSuccessAnimation ? animations.successPulse : {}}
+    >
+      <AnimatePresence mode="wait">
+        {isLoading ? (
+          <motion.div
+            key="loading"
+            {...getAnimation(animations.loadingSpinner)}
+            className={styles.loadingIcon}
+          >
+            <IoClipboard size={18} />
+          </motion.div>
+        ) : showSuccessAnimation ? (
+          <motion.div
+            key="success"
+            initial={{ scale: 0, rotate: -180 }}
+            animate={{ scale: 1, rotate: 0 }}
+            exit={{ scale: 0, rotate: 180 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+          >
+            <IoCheckmark size={18} />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="default"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            {...getAnimation({
+              whileHover: animations.iconHover
+            })}
+          >
+            <IoClipboard size={18} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
+};
+
+export default CopyButton;

--- a/src/components/sidepanel/Editor/Editor.module.css
+++ b/src/components/sidepanel/Editor/Editor.module.css
@@ -148,7 +148,7 @@
 /* MenuBar Styles */
 .controlGroup {
   border-bottom: 1px solid #e0e0e0;
-  padding: 8px 16px;
+  padding: 8px 0px;
   background-color: #f8f9fa;
   border-radius: 8px 8px 0 0;
   position: relative;

--- a/src/components/sidepanel/ExportButton/ExportButton.module.css
+++ b/src/components/sidepanel/ExportButton/ExportButton.module.css
@@ -1,0 +1,88 @@
+.exportButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #333;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+}
+
+.exportButton:hover {
+  background-color: #000;
+  border-color: #000;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.exportButton:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.exportButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(51, 51, 51, 0.3);
+}
+
+.exportButton:disabled {
+  background-color: #f5f5f5;
+  color: #999;
+  border-color: #e1e1e1;
+  cursor: not-allowed;
+}
+
+.exportButton:disabled:hover {
+  background-color: #f5f5f5;
+  border-color: #e1e1e1;
+  transform: none;
+  box-shadow: none;
+}
+
+.tooltipContainer {
+  position: relative;
+  display: flex;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
+  pointer-events: none;
+  z-index: 1000;
+  margin-bottom: 4px;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: #333;
+}
+
+.tooltipContainer:hover .tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.loadingIcon {
+  opacity: 0.7;
+}

--- a/src/sidepanel/pages/ArchiveDetailPage.module.css
+++ b/src/sidepanel/pages/ArchiveDetailPage.module.css
@@ -1,0 +1,246 @@
+.actionButtonsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.primaryActionRow {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.secondaryActionRow {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.singleRowActions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.utilityRow {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Primary Action Button - Edit */
+.primaryActionButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background-color: #000;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.primaryActionButton:hover {
+  background-color: #333;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.primaryActionButton:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.primaryActionButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+}
+
+/* Icon-only Edit Mode Buttons - Black/White Theme */
+.editPrimaryButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background-color: #000;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.editPrimaryButton:hover {
+  background-color: #333;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.editPrimaryButton:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.editPrimaryButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.2);
+}
+
+.editPrimaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.editPrimaryButton:disabled:hover {
+  transform: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.editSecondaryButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.editSecondaryButton:hover {
+  background-color: #e9ecef;
+  color: #495057;
+  border-color: #adb5bd;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.editSecondaryButton:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.editSecondaryButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(108, 117, 125, 0.2);
+}
+
+.editSecondaryButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.editSecondaryButton:disabled:hover {
+  transform: none;
+  background-color: #f8f9fa;
+  border-color: #e9ecef;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+/* Loading Spinner for Save Button - Framer Motion handles animation */
+.loadingSpinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #ffffff40;
+  border-top: 2px solid #ffffff;
+  border-radius: 50%;
+  /* Framer Motion handles the rotation animation */
+}
+
+/* Version Controls - Consistent with Preview Mode */
+.versionControls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.versionSelector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.versionLabel {
+  font-size: 13px;
+  color: #666;
+  font-weight: 500;
+}
+
+.versionSelect {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  background-color: #fff;
+  cursor: pointer;
+  /* Remove CSS transitions as Framer Motion handles them */
+  min-width: 60px;
+}
+
+.versionSelect:hover {
+  border-color: #bbb;
+  background-color: #f8f9fa;
+}
+
+.versionSelect:focus {
+  outline: none;
+  border-color: #000;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+}
+
+.versionSelect:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #f8f9fa;
+}
+
+/* Edit Mode Layout - Consistent with Preview Mode */
+.editModeActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.editModeButtons {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 400px) {
+  .secondaryActionRow {
+    flex-direction: column;
+    gap: 6px;
+  }
+  
+  .actionButtonsContainer {
+    gap: 10px;
+  }
+  
+  .editModeActions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+  
+  .editModeButtons {
+    justify-content: flex-end;
+  }
+}

--- a/src/sidepanel/pages/ArchiveDetailPage.tsx
+++ b/src/sidepanel/pages/ArchiveDetailPage.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { IoArrowBack, IoCreate, IoClose } from 'react-icons/io5';
+import { IoArrowBack, IoCreate, IoClose, IoCheckmark } from 'react-icons/io5';
 import styles from './PageStyles.module.css';
+import detailStyles from './ArchiveDetailPage.module.css';
 import { articleService, ArticleResponse, UpdateArticleDto, ArchiveResponse } from '../../services/articleService';
 import EditorWrapper from '../../components/sidepanel/Editor/Editor';
 import MarkdownRenderer from '../../utils/markdownRenderer';
 import { markdownToHtml } from '../../utils/markdownConverter';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import ExportButton from '../../components/sidepanel/ExportButton/ExportButton';
+import CopyButton from '../../components/sidepanel/CopyButton/CopyButton';
 import { useEditor } from '@tiptap/react'
 import { CharacterCount } from '@tiptap/extension-character-count'
 import Document from '@tiptap/extension-document'
@@ -44,6 +46,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
       }
     });
   }, []);
+
 
   useEffect(() => {
     const fetchArticle = async () => {
@@ -268,14 +271,18 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
         {!isEditing ? (
           // 미리보기 페이지: 두 줄 레이아웃
           <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
-            <div className={styles.rightActionButtons}>
+            <div className={styles.rightActionButtons} style={{display: 'flex', justifyContent: 'flex-end'}}>
+              {/* ExportButton은 항상 렌더링하고 내부에서 maily 페이지 체크 */}
               <ExportButton 
                 title={currentArchive?.title || article.title}
                 content={currentArchive?.content || article.content}
               />
-              <button className={styles.editButton} onClick={handleEdit} title="초안 수정하기">
+              <CopyButton 
+                title={currentArchive?.title || article.title}
+                content={currentArchive?.content || article.content}
+              />
+              <button className={detailStyles.primaryActionButton} onClick={handleEdit} title="초안 수정하기">
                 <IoCreate size={20} />
-                수정
               </button>
             </div>
             <div className={styles.versionControls} style={{display: 'flex', justifyContent: 'flex-end'}}>
@@ -302,25 +309,27 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
             </div>
           </div>
         ) : (
-          // 수정 페이지: 한 줄 레이아웃
-          <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px'}}>
-            <div className={styles.rightActionButtons}>
+          // 수정 페이지: 두 줄 레이아웃 (저장/취소 위, 버전 아래)
+          <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+            <div className={styles.rightActionButtons} style={{display: 'flex', justifyContent: 'flex-end'}}>
               <button 
-                className={styles.saveButton}
+                className={detailStyles.editPrimaryButton}
                 onClick={handleSave}
                 disabled={saving}
+                title={saving ? '저장 중...' : '저장'}
               >
-                {saving ? '저장 중...' : '저장'}
+                <IoCheckmark size={18} />
               </button>
               <button 
-                className={styles.cancelButton}
+                className={detailStyles.editSecondaryButton}
                 onClick={handleCancel}
                 disabled={saving}
+                title="취소"
               >
-                취소
+                <IoClose size={18} />
               </button>
             </div>
-            <div className={styles.versionControls}>
+            <div className={styles.versionControls} style={{display: 'flex', justifyContent: 'flex-end'}}>
               {article.archives && article.archives.length > 0 && (
                 <div className={styles.versionSelector}>
                   <label htmlFor="version-select" className={styles.versionLabel}>

--- a/src/sidepanel/pages/PageStyles.module.css
+++ b/src/sidepanel/pages/PageStyles.module.css
@@ -1227,8 +1227,10 @@ div.contentDisplay ol li {
 .editButton {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
   background-color: #f8f8f8;
   border: 1px solid #e0e0e0;
   border-radius: 8px;
@@ -1655,9 +1657,8 @@ div.contentDisplay ol li {
   overflow-y: auto;
   padding: 0 24px 24px;
   border: 1px solid #eee;
-  border-radius: 12px;
   background-color: #fff;
-  margin: 0 24px;
+  margin: 0px;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.02);
 }
 
@@ -2038,17 +2039,20 @@ div.contentDisplay ol li {
 }
 
 .saveButton {
-  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
   height: 36px;
+  padding: 0;
   background-color: #000;
   color: #fff;
   border: none;
-  border-radius: 10px;
+  border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
-  min-width: 80px;
 }
 
 .saveButton:hover {
@@ -2063,17 +2067,20 @@ div.contentDisplay ol li {
 }
 
 .cancelButton {
-  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
   height: 36px;
+  padding: 0;
   background-color: #f7f7f7;
   color: #000;
   border: 1px solid #eaeaea;
-  border-radius: 10px;
+  border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
-  min-width: 80px;
 }
 
 .cancelButton:hover {


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-232](https://linear.app/chill-mato/issue/CHI-232/)

## 📋 변경 요약
<!-- 주요 변경사항을 한두 줄로 요약해주세요 -->
- 클립보드 복사 기능 추가
- 메일리 에디터일때만 내보내기 기능 display
- editor control group style 수정

## 🛠 주요 변경사항
- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] UI/UX 개선
- [ ] 리팩토링

## 🧪 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 🎨 스크린샷/데모 (선택)
<!-- UI 변경/신규 기능이 있다면 첨부 -->
<img width="563" height="970" alt="스크린샷 2025-08-02 오전 12 23 13" src="https://github.com/user-attachments/assets/95ace30b-d28d-4f49-ac37-0ee66b858cef" />
<img width="561" height="763" alt="스크린샷 2025-08-02 오전 12 23 29" src="https://github.com/user-attachments/assets/3786b4dd-f198-4204-b465-a6318cd18e64" />

## 📦 기타 참고사항
<!-- 리뷰어가 중점적으로 봐야 할 부분, 추가 설명 등 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard button to the archive detail page, allowing users to easily copy formatted content.
  * Introduced new and improved button styles for copy, export, and archive detail actions, including icon-only buttons and tooltips.
  * Enhanced layout and alignment of action buttons for both preview and edit modes on the archive detail page.

* **Style**
  * Unified button sizes, spacing, and alignment across the side panel for a more consistent and accessible UI.
  * Improved responsive layouts for action controls and version selectors.
  * Updated padding and margin for better visual balance in the editor and side panel content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->