### PR TITLE
[CHI-266] 문체 삭제 기능 추가

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tyquill",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tyquill은 뉴스레터 작성에 관한 소모성 작업을 줄이고 창작에 열중할 수 있게 돕습니다.",
   "permissions": [
     "storage", 

--- a/src/sidepanel/pages/StyleManagementPage.module.css
+++ b/src/sidepanel/pages/StyleManagementPage.module.css
@@ -548,6 +548,7 @@
   align-items: center;
   padding: 20px 20px 16px 20px;
   border-bottom: 1px solid #e0e0e0;
+  position: relative;
 }
 
 .styleCardTitle {
@@ -568,12 +569,39 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  z-index: 10;
+  min-width: 32px;
+  min-height: 32px;
+  outline: none;
 }
 
 .deleteButton:hover {
   background: #fee2e2;
   border-color: #fca5a5;
   transform: scale(1.05);
+}
+
+.deleteButton:focus {
+  outline: 2px solid #dc2626;
+  outline-offset: 2px;
+}
+
+.deleteButton:active {
+  transform: scale(0.95);
+}
+
+.deleteButton.deleting {
+  opacity: 0.7;
+  cursor: not-allowed;
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.deleteButton.deleting:hover {
+  transform: none;
+  background: #f3f4f6;
+  border-color: #d1d5db;
 }
 
 .styleCardContent {
@@ -703,8 +731,8 @@
 .spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top: 2px solid white;
+  border: 2px solid rgba(220, 38, 38, 0.3);
+  border-top: 2px solid #dc2626;
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }


### PR DESCRIPTION
## 연관 이슈
Closes: [CHI-266](https://linear.app/chill-mato/issue/CHI-266/)

## 변경 요약
문체 관리 페이지 삭제 버튼 클릭 이슈 해결 및 UX 개선

## 주요 변경사항

### 버그 수정
- 삭제 버튼 클릭 안됨 이슈 해결
  - `e.stopPropagation()` 추가로 이벤트 버블링 방지
  - CSS `z-index: 10` 설정으로 클릭 영역 확보

### UX 개선
- 로컬 상태 관리로 즉시 반영 (새로고침 불필요)
- 개별 삭제 로딩 상태 표시
- 접근성 속성 추가 (`aria-label`, `type="button"`)

## 테스트
- [x] 빌드 확인
- [x] 삭제 버튼 정상 클릭 확인
- [x] 문체 추가/삭제 즉시 반영 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-item deletion now shows a spinner and disables the button while in progress.
  * Styles list updates immediately after adding a new style, reducing wait time.
  * Refresh retrieves the latest styles without a full reload.

* **Style**
  * Improved delete button interactions: focus outline, active press effect, and visual “deleting” state.
  * Spinner updated to a red theme for error/urgency cues.
  * Layout tweaks for more reliable button layering.

* **Chores**
  * Bumped app version to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->