### PR TITLE
[CHI-269] ScrapPage 레이아웃 관련 버그 수정

### DIFF
--- a/src/sidepanel/pages/PageStyles.module.css
+++ b/src/sidepanel/pages/PageStyles.module.css
@@ -19,13 +19,15 @@
 .pageContainer {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
   background-color: #ffffff;
 }
 
 .page {
   padding: 16px 2vw;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   background-color: #ffffff;
 }
@@ -1543,7 +1545,7 @@ div.contentDisplay ol li {
   padding: 20px;
   border-bottom: 1px solid #eee;
   z-index: 10;
-  height: 14vh;
+  flex-shrink: 0;
 }
 
 .tagFilterContainer {
@@ -1655,14 +1657,15 @@ div.contentDisplay ol li {
 
 /* Scrollable Content */
 .scrollableContent {
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   padding: 0 24px 24px;
   border: 1px solid #eee;
   background-color: #fff;
   margin: 0px;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.02);
-  height: 80vh;
+  flex: 1;
+  min-height: 0;
 }
 
 .scrollableContent::-webkit-scrollbar {


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-269](https://linear.app/chill-mato/issue/CHI-269/)

## 변경 요약
임시로 땜빵(vh 사용)했던 페이지 스타일을 flexbox 형태로 올바르게 수정 (반응형 o)

## 주요 변경사항
pageStyles.module.css

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 스크린샷/데모 (선택)
<!-- UI 변경/신규 기능이 있다면 첨부 -->
<img width="486" height="376" alt="SCR-20250820-qtal" src="https://github.com/user-attachments/assets/94cb4809-b66c-44e1-bf95-39b875424ae9" />
<img width="544" height="324" alt="SCR-20250820-qtck" src="https://github.com/user-attachments/assets/5644766a-a456-4002-828e-96c8a0a47b18" />

## 기타 참고사항
<!-- 리뷰어가 중점적으로 봐야 할 부분, 추가 설명 등 -->
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents content clipping in the side panel and ensures headers and list items don’t shrink unexpectedly.
  * Scrollbars now appear only when needed, reducing visual clutter.
  * Scroll areas expand correctly across screen sizes for smoother navigation.

* **Refactor**
  * Transitioned side panel layout to flexible, content-driven sizing, replacing rigid viewport-based heights.
  * Improved responsiveness and readability of scrollable and fixed sections for a more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->