### PR TITLE
[CHI-277] Uninstall URL 변경

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -385,5 +385,5 @@ export default defineBackground(() => {
     // console.log('Tyquill Extension installed with context menus');
   });
 
-  browser.runtime.setUninstallURL('https://tally.so/r/3EOeqN');
+  browser.runtime.setUninstallURL('https://tally.so/r/nGZK7z');
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -384,6 +384,6 @@ browser.runtime.onInstalled.addListener(async () => {
   // console.log('Tyquill Extension installed with context menus');
 });
 
-browser.runtime.setUninstallURL('https://tally.so/r/3EOeqN');
+browser.runtime.setUninstallURL('https://tally.so/r/nGZK7z');
 
 export {}; 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-277](https://linear.app/chill-mato/issue/CHI-277/)

## 변경 요약
<!-- 주요 변경사항을 한두 줄로 요약해주세요 -->
삭제 시 이동 URL 변경
## 주요 변경사항
Tally 폼 URL변경으로 인한 삭제 시 이동 URL 변경
## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 스크린샷/데모 (선택)
<!-- UI 변경/신규 기능이 있다면 첨부 -->

## 기타 참고사항
<!-- 리뷰어가 중점적으로 봐야 할 부분, 추가 설명 등 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the post-uninstall feedback link to a new survey URL, directing users to the latest feedback form when they remove the extension.
  * No changes to day-to-day features, permissions, or performance.
  * Background behavior, context menus, and handlers remain unchanged to ensure stability and a consistent user experience.
  * This update only affects the experience after uninstalling the extension; all in-app functionality continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->