### PR TITLE
Iss/chi 287

### DIFF
--- a/src/components/sidepanel/PDFUploadModal/PDFUploadModal.module.css
+++ b/src/components/sidepanel/PDFUploadModal/PDFUploadModal.module.css
@@ -1,0 +1,412 @@
+/* Modal Overlay */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Modal Content */
+.modalContent {
+  background: white;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* Modal Header */
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.modalTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.closeButton:hover {
+  background-color: #f1f5f9;
+  color: #334155;
+}
+
+.closeButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Modal Body */
+.modalBody {
+  padding: 24px;
+}
+
+/* Dropzone */
+.dropzone {
+  border: 2px dashed #e2e8f0;
+  border-radius: 8px;
+  padding: 32px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: #f8fafc;
+  margin-bottom: 24px;
+}
+
+.dropzone:hover {
+  border-color: #cbd5e1;
+  background-color: #f1f5f9;
+}
+
+.dropzone.dragging {
+  border-color: #3b82f6;
+  background-color: #eff6ff;
+}
+
+.dropzone.hasFile {
+  cursor: default;
+  background-color: #f0f9ff;
+  border-color: #3b82f6;
+}
+
+.uploadIcon {
+  color: #94a3b8;
+  margin-bottom: 12px;
+}
+
+.dropzoneText {
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  margin-bottom: 4px;
+}
+
+.dropzoneSubtext {
+  font-size: 12px;
+  color: #64748b;
+}
+
+/* Selected File Display */
+.selectedFile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.fileIcon {
+  color: #3b82f6;
+}
+
+.fileName {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1e293b;
+  word-break: break-all;
+}
+
+.fileSize {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.changeFileButton {
+  margin-top: 8px;
+  padding: 6px 12px;
+  background-color: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #475569;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.changeFileButton:hover {
+  background-color: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+/* Form Groups */
+.formGroup {
+  margin-bottom: 20px;
+}
+
+.label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  margin-bottom: 8px;
+}
+
+.required {
+  color: #ef4444;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #1e293b;
+  background-color: white;
+  transition: all 0.2s ease;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.input:disabled,
+.textarea:disabled {
+  background-color: #f8fafc;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 80px;
+  font-family: inherit;
+}
+
+/* Tag Input */
+.tagInputWrapper {
+  display: flex;
+  gap: 8px;
+}
+
+.tagInput {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #1e293b;
+  background-color: white;
+  transition: all 0.2s ease;
+}
+
+.tagInput:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.tagInput:disabled {
+  background-color: #f8fafc;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.addTagButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.addTagButton:hover {
+  background-color: #2563eb;
+}
+
+.addTagButton:disabled {
+  background-color: #cbd5e1;
+  cursor: not-allowed;
+}
+
+/* Tag List */
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background-color: #eff6ff;
+  border: 1px solid #dbeafe;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #1e40af;
+}
+
+.removeTagButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: #60a5fa;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 2px;
+  transition: color 0.2s ease;
+}
+
+.removeTagButton:hover {
+  color: #2563eb;
+}
+
+.removeTagButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Modal Footer */
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 20px 24px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.cancelButton,
+.uploadButton {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.cancelButton {
+  background-color: white;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+}
+
+.cancelButton:hover {
+  background-color: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.cancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.uploadButton {
+  background-color: #3b82f6;
+  color: white;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.uploadButton:hover {
+  background-color: #2563eb;
+}
+
+.uploadButton:disabled {
+  background-color: #cbd5e1;
+  cursor: not-allowed;
+}
+
+/* Loading Spinner */
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .modalContent {
+    width: 95%;
+    max-height: 95vh;
+  }
+
+  .modalHeader,
+  .modalFooter {
+    padding: 16px 20px;
+  }
+
+  .modalBody {
+    padding: 20px;
+  }
+
+  .dropzone {
+    padding: 24px;
+  }
+}

--- a/src/components/sidepanel/PDFUploadModal/PDFUploadModal.tsx
+++ b/src/components/sidepanel/PDFUploadModal/PDFUploadModal.tsx
@@ -1,0 +1,306 @@
+import React, { useState, useCallback, useRef } from 'react';
+import { IoClose, IoCloudUpload, IoDocument, IoAdd } from 'react-icons/io5';
+import styles from './PDFUploadModal.module.css';
+import { uploadService } from '../../../services/uploadService';
+import { useToastHelpers } from '../../../hooks/useToast';
+
+interface PDFUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUploadSuccess: () => void;
+}
+
+export const PDFUploadModal: React.FC<PDFUploadModalProps> = ({
+  isOpen,
+  onClose,
+  onUploadSuccess,
+}) => {
+  const { showSuccess, showError } = useToastHelpers();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const resetForm = () => {
+    setSelectedFile(null);
+    setTitle('');
+    setDescription('');
+    setTags([]);
+    setTagInput('');
+    setIsDragging(false);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleClose = () => {
+    if (!isUploading) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  const handleFileSelect = (file: File) => {
+    if (file.type !== 'application/pdf') {
+      showError('파일 형식 오류', 'PDF 파일만 업로드 가능합니다.');
+      return;
+    }
+
+    if (file.size > 50 * 1024 * 1024) {
+      showError('파일 크기 초과', '50MB 이하의 파일만 업로드 가능합니다.');
+      return;
+    }
+
+    setSelectedFile(file);
+    // 파일명에서 제목 자동 추출 (확장자 제거)
+    if (!title) {
+      setTitle(file.name.replace(/\.pdf$/i, ''));
+    }
+  };
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    const pdfFile = files.find(file => file.type === 'application/pdf');
+
+    if (pdfFile) {
+      handleFileSelect(pdfFile);
+    } else {
+      showError('파일 형식 오류', 'PDF 파일만 업로드 가능합니다.');
+    }
+  }, []);
+
+  const handleAddTag = () => {
+    const trimmedTag = tagInput.trim();
+    if (trimmedTag && !tags.includes(trimmedTag)) {
+      setTags([...tags, trimmedTag]);
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(tags.filter(tag => tag !== tagToRemove));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddTag();
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) {
+      showError('파일 선택 필요', 'PDF 파일을 선택해주세요.');
+      return;
+    }
+
+    if (!title.trim()) {
+      showError('제목 입력 필요', '제목을 입력해주세요.');
+      return;
+    }
+
+    try {
+      setIsUploading(true);
+
+      // 메타데이터와 함께 파일 업로드 (서버가 S3 업로드 + DB 저장까지 수행)
+      await uploadService.uploadPDF(
+        selectedFile,
+        title.trim(),
+        description.trim(),
+      );
+
+      showSuccess('업로드 완료', `${selectedFile.name}이 성공적으로 업로드되었습니다.`);
+      resetForm();
+      onUploadSuccess();
+      onClose();
+    } catch (error: any) {
+      console.error('PDF upload error:', error);
+      showError('업로드 실패', error.message || 'PDF 업로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.modalOverlay} onClick={handleClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>
+            <IoDocument size={20} />
+            PDF 업로드
+          </h2>
+          <button
+            className={styles.closeButton}
+            onClick={handleClose}
+            disabled={isUploading}
+          >
+            <IoClose size={20} />
+          </button>
+        </div>
+
+        <div className={styles.modalBody}>
+          {/* 파일 선택 영역 */}
+          <div
+            className={`${styles.dropzone} ${isDragging ? styles.dragging : ''} ${selectedFile ? styles.hasFile : ''}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => !selectedFile && fileInputRef.current?.click()}
+          >
+            {selectedFile ? (
+              <div className={styles.selectedFile}>
+                <IoDocument size={32} className={styles.fileIcon} />
+                <div className={styles.fileName}>{selectedFile.name}</div>
+                <div className={styles.fileSize}>
+                  {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                </div>
+                <button
+                  className={styles.changeFileButton}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    fileInputRef.current?.click();
+                  }}
+                >
+                  파일 변경
+                </button>
+              </div>
+            ) : (
+              <>
+                <IoCloudUpload size={40} className={styles.uploadIcon} />
+                <div className={styles.dropzoneText}>
+                  {isDragging
+                    ? 'PDF 파일을 여기에 놓아주세요'
+                    : 'PDF 파일을 드래그하거나 클릭하여 선택'}
+                </div>
+                <div className={styles.dropzoneSubtext}>최대 50MB</div>
+              </>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,application/pdf"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  handleFileSelect(file);
+                }
+              }}
+              style={{ display: 'none' }}
+            />
+          </div>
+
+          {/* 메타데이터 입력 영역 */}
+          <div className={styles.formGroup}>
+            <label className={styles.label}>
+              제목 <span className={styles.required}>*</span>
+            </label>
+            <input
+              type="text"
+              className={styles.input}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="PDF 문서의 제목을 입력하세요"
+              disabled={isUploading}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.label}>설명</label>
+            <textarea
+              className={styles.textarea}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="문서에 대한 설명을 입력하세요 (선택사항)"
+              rows={3}
+              disabled={isUploading}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.label}>태그</label>
+            <div className={styles.tagInputWrapper}>
+              <input
+                type="text"
+                className={styles.tagInput}
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="태그 입력 후 Enter"
+                disabled={isUploading}
+              />
+              <button
+                className={styles.addTagButton}
+                onClick={handleAddTag}
+                disabled={!tagInput.trim() || isUploading}
+              >
+                <IoAdd size={16} />
+              </button>
+            </div>
+            {tags.length > 0 && (
+              <div className={styles.tagList}>
+                {tags.map((tag) => (
+                  <span key={tag} className={styles.tag}>
+                    {tag}
+                    <button
+                      className={styles.removeTagButton}
+                      onClick={() => handleRemoveTag(tag)}
+                      disabled={isUploading}
+                    >
+                      <IoClose size={14} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.modalFooter}>
+          <button
+            className={styles.cancelButton}
+            onClick={handleClose}
+            disabled={isUploading}
+          >
+            취소
+          </button>
+          <button
+            className={styles.uploadButton}
+            onClick={handleUpload}
+            disabled={!selectedFile || !title.trim() || isUploading}
+          >
+            {isUploading ? (
+              <>
+                <span className={styles.spinner} />
+                업로드 중...
+              </>
+            ) : (
+              '업로드'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/sidepanel/PDFUploadModal/PDFUploadModal.tsx
+++ b/src/components/sidepanel/PDFUploadModal/PDFUploadModal.tsx
@@ -19,8 +19,6 @@ export const PDFUploadModal: React.FC<PDFUploadModalProps> = ({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState('');
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -29,8 +27,6 @@ export const PDFUploadModal: React.FC<PDFUploadModalProps> = ({
     setSelectedFile(null);
     setTitle('');
     setDescription('');
-    setTags([]);
-    setTagInput('');
     setIsDragging(false);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -88,25 +84,6 @@ export const PDFUploadModal: React.FC<PDFUploadModalProps> = ({
       showError('파일 형식 오류', 'PDF 파일만 업로드 가능합니다.');
     }
   }, []);
-
-  const handleAddTag = () => {
-    const trimmedTag = tagInput.trim();
-    if (trimmedTag && !tags.includes(trimmedTag)) {
-      setTags([...tags, trimmedTag]);
-      setTagInput('');
-    }
-  };
-
-  const handleRemoveTag = (tagToRemove: string) => {
-    setTags(tags.filter(tag => tag !== tagToRemove));
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleAddTag();
-    }
-  };
 
   const handleUpload = async () => {
     if (!selectedFile) {
@@ -236,44 +213,6 @@ export const PDFUploadModal: React.FC<PDFUploadModalProps> = ({
               rows={3}
               disabled={isUploading}
             />
-          </div>
-
-          <div className={styles.formGroup}>
-            <label className={styles.label}>태그</label>
-            <div className={styles.tagInputWrapper}>
-              <input
-                type="text"
-                className={styles.tagInput}
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="태그 입력 후 Enter"
-                disabled={isUploading}
-              />
-              <button
-                className={styles.addTagButton}
-                onClick={handleAddTag}
-                disabled={!tagInput.trim() || isUploading}
-              >
-                <IoAdd size={16} />
-              </button>
-            </div>
-            {tags.length > 0 && (
-              <div className={styles.tagList}>
-                {tags.map((tag) => (
-                  <span key={tag} className={styles.tag}>
-                    {tag}
-                    <button
-                      className={styles.removeTagButton}
-                      onClick={() => handleRemoveTag(tag)}
-                      disabled={isUploading}
-                    >
-                      <IoClose size={14} />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            )}
           </div>
         </div>
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -324,9 +324,9 @@ class AuthService {
       }
     }
 
+    // 기본적으로 Authorization만 설정하고, Content-Type은 요청 본문 유형에 맞게 호출부에서 결정
     return {
       'Authorization': `Bearer ${this.authState.accessToken}`,
-      'Content-Type': 'application/json',
     };
   }
 

--- a/src/services/globalApiClient.ts
+++ b/src/services/globalApiClient.ts
@@ -81,12 +81,31 @@ export class GlobalApiClient {
 
     try {
       // 인증이 필요한 경우 토큰 가져오기
-      const headers = await authService.getAuthHeaders();
-
+      const authHeaders = await authService.getAuthHeaders();
       const url = `${this.apiUrl}${endpoint}`;
+
+      // FormData 여부 판단 및 헤더 병합
+      const isFormData =
+        typeof FormData !== 'undefined' && requestOptions.body instanceof FormData;
+
+      const mergedHeaders: Record<string, string> = {
+        ...authHeaders,
+        ...(requestOptions.headers || {}),
+      };
+
+      // JSON 자동 직렬화 (FormData가 아닌 경우에만)
+      let body: any = requestOptions.body;
+      if (!isFormData && body && typeof body !== 'string') {
+        body = JSON.stringify(body);
+        if (!mergedHeaders['Content-Type']) {
+          mergedHeaders['Content-Type'] = 'application/json';
+        }
+      }
+
       const config: RequestInit = {
         ...requestOptions,
-        headers,
+        body,
+        headers: mergedHeaders,
       };
 
       const response = await fetch(url, config);
@@ -97,9 +116,8 @@ export class GlobalApiClient {
           try {
             // console.log('🔄 401 error detected, refreshing token...');
             const newToken = await this.refreshAccessToken();
-            headers['Authorization'] = `Bearer ${newToken}`;
-            
-            const retryResponse = await fetch(url, { ...config, headers });
+            const retryHeaders = { ...mergedHeaders, Authorization: `Bearer ${newToken}` };
+            const retryResponse = await fetch(url, { ...config, headers: retryHeaders });
             
             if (!retryResponse.ok) {
               throw new Error(`API Error: ${retryResponse.status} ${retryResponse.statusText}`);
@@ -141,7 +159,7 @@ export class GlobalApiClient {
     return this.request<T>(endpoint, {
       ...options,
       method: 'POST',
-      body: data ? JSON.stringify(data) : undefined,
+      body: data,
     });
   }
 
@@ -152,7 +170,7 @@ export class GlobalApiClient {
     return this.request<T>(endpoint, {
       ...options,
       method: 'PUT',
-      body: data ? JSON.stringify(data) : undefined,
+      body: data,
     });
   }
 
@@ -163,7 +181,7 @@ export class GlobalApiClient {
     return this.request<T>(endpoint, {
       ...options,
       method: 'PATCH',
-      body: data ? JSON.stringify(data) : undefined,
+      body: data,
     });
   }
 

--- a/src/services/globalApiClient.ts
+++ b/src/services/globalApiClient.ts
@@ -100,6 +100,11 @@ export class GlobalApiClient {
         if (!mergedHeaders['Content-Type']) {
           mergedHeaders['Content-Type'] = 'application/json';
         }
+      } else if (!isFormData && typeof body === 'string') {
+        // 문자열 본문인 경우에도 기본적으로 JSON으로 간주하여 헤더 보완
+        if (!mergedHeaders['Content-Type']) {
+          mergedHeaders['Content-Type'] = 'application/json';
+        }
       }
 
       const config: RequestInit = {

--- a/src/services/libraryItemService.ts
+++ b/src/services/libraryItemService.ts
@@ -1,0 +1,27 @@
+import { globalApiClient } from './globalApiClient';
+
+export type LibraryItemType = 'SCRAP' | 'UPLOAD';
+
+export interface LibraryItemDto {
+  id: number;
+  type: LibraryItemType;
+  title: string;
+  description?: string;
+  previewText?: string;
+  url?: string;
+  mimeType?: string;
+  fileSize?: number;
+  createdAt: string;
+  updatedAt?: string;
+  tags?: string[];
+}
+
+class LibraryItemService {
+  async list(type?: LibraryItemType): Promise<LibraryItemDto[]> {
+    const query = type ? `?type=${type}` : '';
+    return globalApiClient.get(`/v1/library-items${query}`);
+  }
+}
+
+export const libraryItemService = new LibraryItemService();
+

--- a/src/services/libraryItemService.ts
+++ b/src/services/libraryItemService.ts
@@ -16,10 +16,30 @@ export interface LibraryItemDto {
   tags?: string[];
 }
 
+export interface TagDto {
+  tagId: number;
+  name: string;
+  createdAt?: string;
+}
+
 class LibraryItemService {
   async list(type?: LibraryItemType): Promise<LibraryItemDto[]> {
     const query = type ? `?type=${type}` : '';
     return globalApiClient.get(`/v1/library-items${query}`);
+  }
+
+  async addTag(itemId: number, itemType: LibraryItemType, tagName: string): Promise<TagDto> {
+    return globalApiClient.post(`/v1/library-items/${itemId}/tags?type=${itemType}`, {
+      name: tagName
+    });
+  }
+
+  async removeTag(itemId: number, itemType: LibraryItemType, tagId: number): Promise<void> {
+    return globalApiClient.delete(`/v1/library-items/${itemId}/tags/${tagId}?type=${itemType}`);
+  }
+
+  async getTags(itemId: number, itemType: LibraryItemType): Promise<TagDto[]> {
+    return globalApiClient.get(`/v1/library-items/${itemId}/tags?type=${itemType}`);
   }
 }
 

--- a/src/services/scrapService.ts
+++ b/src/services/scrapService.ts
@@ -77,6 +77,9 @@ export class ScrapService {
 
       const response = await this.apiRequest<ScrapResponse>('/v1/scraps', {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(scrapData),
       });
 

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -55,6 +55,9 @@ export class TagService {
         const endpoint = scrapId ? `/v1/tags?scrapId=${scrapId}` : '/v1/tags';
         return this.apiRequest(endpoint, {
             method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
             body: JSON.stringify(tagData),
         });
     }
@@ -96,6 +99,9 @@ export class TagService {
     async updateTag(tagId: number, updateData: UpdateTagDto): Promise<TagResponse> {
         return this.apiRequest(`/v1/tags/${tagId}`, {
             method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
             body: JSON.stringify(updateData),
         });
     }
@@ -107,6 +113,9 @@ export class TagService {
     async deleteTag(tagId: number): Promise<void> {
         return this.apiRequest(`/v1/tags/${tagId}`, {
             method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
         });
     }
 

--- a/src/services/uploadService.ts
+++ b/src/services/uploadService.ts
@@ -1,0 +1,67 @@
+import { globalApiClient } from './globalApiClient';
+import { browser } from 'wxt/browser';
+
+interface UploadResponse {
+  url: string;
+  name: string;
+  size: number;
+  uploadedBy: number;
+  title?: string;
+  description?: string;
+}
+
+interface FileMetadata { title?: string; description?: string }
+
+class UploadService {
+  private uploadEndpoint = '/v1/uploaded-files/upload';
+
+  async uploadFile(file: File, metadata?: FileMetadata): Promise<UploadResponse> {
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      
+      // 메타데이터를 별도 필드로 추가
+      if (metadata?.title) {
+        formData.append('title', metadata.title);
+      }
+      
+      if (metadata?.description) {
+        formData.append('description', metadata.description);
+      }
+
+      // S3 업로드 엔드포인트 호출
+      const response = await globalApiClient.post<any>(this.uploadEndpoint, formData);
+
+      return {
+        url: response.filePath,
+        name: response.fileName,
+        size: response.fileSize,
+        uploadedBy: response.user?.userId || 0,
+        title: response.title,
+        description: response.description,
+      };
+    } catch (error: any) {
+      console.error('Upload error:', error);
+      throw new Error(error.message || 'Failed to upload file');
+    }
+  }
+
+  async uploadPDF(pdfFile: File, title?: string, description?: string): Promise<UploadResponse> {
+    if (pdfFile.type !== 'application/pdf') {
+      throw new Error('Only PDF files are supported');
+    }
+
+    // 서버에서 현재 50MB 제한. 필요 시 조정 가능
+    if (pdfFile.size > 50 * 1024 * 1024) {
+      throw new Error('파일 크기는 50MB 이하여야 합니다.');
+    }
+
+    return this.uploadFile(pdfFile, {
+      title: title || pdfFile.name.replace(/\.pdf$/i, ''),
+      description: description || '',
+    });
+  }
+  // For pre-signed flow (not used in server-proxy mode), we would add a separate method.
+}
+
+export const uploadService = new UploadService();

--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { IoAdd, IoTrash, IoClose, IoClipboard, IoCheckmark, IoRefresh, IoDocument, IoCloudUpload } from 'react-icons/io5';
+import { IoAdd, IoTrash, IoClose, IoClipboard, IoCheckmark, IoRefresh, IoDocument } from 'react-icons/io5';
 import { browser } from 'wxt/browser';
 import styles from './PageStyles.module.css';
 import scrapStyles from './ScrapPage.module.css';
@@ -12,6 +12,8 @@ import { Scrap } from '../../types/scrap.d';
 import { clipAndScrapCurrentPage, ScrapStatus } from '../../utils/scrapHelper';
 import { markdownToPlainTextPreview } from '../../utils/markdownConverter';
 import Tooltip from '../../components/common/Tooltip';
+import { PDFUploadModal } from '../../components/sidepanel/PDFUploadModal/PDFUploadModal';
+import { libraryItemService, type LibraryItemDto } from '../../services/libraryItemService';
 
 const ScrapPage: React.FC = () => {
   const { showSuccess, showError, showWarning } = useToastHelpers();
@@ -28,15 +30,17 @@ const ScrapPage: React.FC = () => {
   const [scraps, setScraps] = useState<Scrap[]>([]);
   const [scrapsLoading, setScrapsLoading] = useState(false);
   const [scrapsError, setScrapsError] = useState<string | null>(null);
+  const [uploads, setUploads] = useState<LibraryItemDto[]>([]);
+  const [uploadsLoading, setUploadsLoading] = useState(false);
+  const [uploadsError, setUploadsError] = useState<string | null>(null);
+  const [viewType, setViewType] = useState<'SCRAP' | 'UPLOAD'>('SCRAP');
   const observerRef = useRef<IntersectionObserver>();
   const lastScrapRef = useRef<HTMLDivElement>(null);
   const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const inputRef = useRef<HTMLInputElement>(null);
   const [allTags, setAllTags] = useState<string[]>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [showUploadArea, setShowUploadArea] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
+  const [showPDFUploadModal, setShowPDFUploadModal] = useState(false);
 
   useEffect(() => {
     const fetchAllTags = async () => {
@@ -99,6 +103,22 @@ const ScrapPage: React.FC = () => {
       }
     } finally {
       setScrapsLoading(false);
+    }
+  }, [isAuthenticated]);
+
+  // 업로드 목록 불러오기
+  const loadUploads = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      setUploadsLoading(true);
+      setUploadsError(null);
+      const items = await libraryItemService.list('UPLOAD');
+      setUploads(items);
+    } catch (error: any) {
+      setUploadsError(error.message || '업로드 목록을 불러오는데 실패했습니다.');
+      if (error.message?.includes('Authentication')) setIsAuthenticated(false);
+    } finally {
+      setUploadsLoading(false);
     }
   }, [isAuthenticated]);
 
@@ -172,19 +192,24 @@ const ScrapPage: React.FC = () => {
   
   // 인증 상태가 변경되면 스크랩 목록 로드
   useEffect(() => {
-    if (isAuthenticated && authChecked) {
+    if (!isAuthenticated || !authChecked) {
+      setScraps([]);
+      setUploads([]);
+      return;
+    }
+    if (viewType === 'SCRAP') {
       loadScraps();
     } else {
-      setScraps([]);
+      loadUploads();
     }
-  }, [isAuthenticated, authChecked, loadScraps]);
+  }, [isAuthenticated, authChecked, viewType, loadScraps, loadUploads]);
 
   // 페이지 visibility 변경 시 스크랩 목록 새로고침
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (!document.hidden && isAuthenticated && authChecked) {
-        // console.log('📱 Side panel visible, refreshing scraps...');
-        loadScraps();
+        if (viewType === 'SCRAP') loadScraps();
+        else loadUploads();
       }
     };
 
@@ -193,7 +218,7 @@ const ScrapPage: React.FC = () => {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [isAuthenticated, authChecked, loadScraps]);
+  }, [isAuthenticated, authChecked, viewType, loadScraps, loadUploads]);
 
   // Background script로부터 스크랩 생성 알림 수신
   useEffect(() => {
@@ -201,8 +226,7 @@ const ScrapPage: React.FC = () => {
     
     const handleScrapCreatedMessage = (message: any) => {
       if (isActive && message.action === 'scrapCreated' && isAuthenticated) {
-        // console.log('📱 Scrap created notification received, refreshing list...');
-        loadScraps();
+        if (viewType === 'SCRAP') loadScraps();
       }
     };
 
@@ -211,7 +235,7 @@ const ScrapPage: React.FC = () => {
     return () => {
       isActive = false;
     };
-  }, [isAuthenticated, loadScraps]);
+  }, [isAuthenticated, viewType, loadScraps]);
 
   // 스크랩에 태그 추가
   const handleAddTag = useCallback(async (scrapId: string, tag: string) => {
@@ -317,80 +341,25 @@ const ScrapPage: React.FC = () => {
     
     try {
       setIsRefreshing(true);
-      await loadScraps();
-      showSuccess('새로고침 완료', '스크랩 목록이 업데이트되었습니다.');
+      if (viewType === 'SCRAP') {
+        await loadScraps();
+        showSuccess('새로고침 완료', '스크랩 목록이 업데이트되었습니다.');
+      } else {
+        await loadUploads();
+        showSuccess('새로고침 완료', '업로드 목록이 업데이트되었습니다.');
+      }
     } catch (error: any) {
-      showError('새로고침 실패', error.message || '스크랩 목록 새로고침에 실패했습니다.');
+      showError('새로고침 실패', error.message || '목록 새로고침에 실패했습니다.');
     } finally {
       setIsRefreshing(false);
     }
-  }, [isAuthenticated, isRefreshing, loadScraps, showSuccess, showError]);
+  }, [isAuthenticated, isRefreshing, viewType, loadScraps, loadUploads, showSuccess, showError]);
 
-  // PDF 파일 업로드 핸들러
-  const handlePDFUpload = useCallback(async (file: File) => {
-    if (!file) return;
-    
-    // PDF 파일 검증
-    if (file.type !== 'application/pdf') {
-      showError('파일 형식 오류', 'PDF 파일만 업로드 가능합니다.');
-      return;
-    }
-    
-    // 파일 크기 제한 (10MB)
-    if (file.size > 10 * 1024 * 1024) {
-      showError('파일 크기 초과', '10MB 이하의 파일만 업로드 가능합니다.');
-      return;
-    }
-    
-    try {
-      setIsUploading(true);
-      
-      // TODO: 실제 UploadThing 서비스 연동
-      // const uploadResult = await uploadFiles([file]);
-      
-      // 임시 시뮬레이션
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      showSuccess('업로드 완료', `${file.name}이 성공적으로 업로드되었습니다.`);
-      setShowUploadArea(false);
-      await loadScraps();
-      
-    } catch (error: any) {
-      console.error('PDF upload error:', error);
-      showError('업로드 실패', error.message || 'PDF 업로드 중 오류가 발생했습니다.');
-    } finally {
-      setIsUploading(false);
-    }
-  }, [showSuccess, showError, loadScraps]);
-
-  // 드래그 앤 드롭 이벤트 핸들러
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-  }, []);
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-  }, []);
-
-  const handleDrop = useCallback(async (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-    
-    const files = Array.from(e.dataTransfer.files);
-    const pdfFile = files.find(file => file.type === 'application/pdf');
-    
-    if (!pdfFile) {
-      showError('파일 형식 오류', 'PDF 파일만 업로드 가능합니다.');
-      return;
-    }
-    
-    await handlePDFUpload(pdfFile);
-  }, [handlePDFUpload, showError]);
+  // PDF 업로드 성공 시 처리
+  const handlePDFUploadSuccess = useCallback(() => {
+    if (viewType === 'SCRAP') loadScraps();
+    else loadUploads();
+  }, [viewType, loadScraps, loadUploads]);
 
   // 로그인 페이지로 이동 (또는 로그아웃 처리)
   const handleLogin = useCallback(async () => {
@@ -597,7 +566,7 @@ const ScrapPage: React.FC = () => {
               
               <button
                 className={`${styles.addButton} ${scrapStyles.pdfUploadButton}`}
-                onClick={() => setShowUploadArea(!showUploadArea)}
+                onClick={() => setShowPDFUploadModal(true)}
               >
                 <IoDocument size={20} />
                 PDF
@@ -606,62 +575,6 @@ const ScrapPage: React.FC = () => {
           )}
         </div>
 
-        {showUploadArea && isAuthenticated && (
-          <div className={`${scrapStyles.uploadSection} ${isUploading ? scrapStyles.uploading : ''}`}>
-            <div className={scrapStyles.uploadDropzoneWrapper}>
-              <div 
-                className={`${scrapStyles.uploadDropzone} ${isDragging ? scrapStyles.dragging : ''}`}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
-                onClick={() => document.getElementById('pdf-file-input')?.click()}
-              >
-                {isUploading ? (
-                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-                    <div className={styles.loadingSpinner} style={{ marginBottom: '8px' }} />
-                    <div style={{ color: '#3b82f6', fontSize: '14px', fontWeight: '500' }}>
-                      업로드 중...
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <IoCloudUpload size={32} style={{ color: '#64748b', marginBottom: '8px' }} />
-                    <div style={{ color: '#334155', fontSize: '14px', fontWeight: '500', marginBottom: '4px' }}>
-                      {isDragging ? 'PDF 파일을 여기에 놓아주세요' : 'PDF 파일을 드래그하거나 클릭하여 업로드'}
-                    </div>
-                    <div style={{ color: '#64748b', fontSize: '12px' }}>
-                      PDF 파일만 지원됩니다 (최대 10MB)
-                    </div>
-                  </>
-                )}
-                <input
-                  type="file"
-                  accept=".pdf,application/pdf"
-                  onChange={async (e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                      await handlePDFUpload(file);
-                      e.target.value = ''; // 입력 필드 자기화
-                    }
-                  }}
-                  style={{ display: 'none' }}
-                  id="pdf-file-input"
-                  disabled={isUploading}
-                />
-              </div>
-            </div>
-            <div className={scrapStyles.uploadActions}>
-              <button 
-                className={scrapStyles.cancelButton}
-                onClick={() => setShowUploadArea(false)}
-                disabled={isUploading}
-              >
-                <IoClose size={16} />
-                취소
-              </button>
-            </div>
-          </div>
-        )}
 
         <div className={styles.headerControls}>
           <TagSelector
@@ -672,6 +585,22 @@ const ScrapPage: React.FC = () => {
             )}
             onTagRemove={(tag) => setSelectedTags(prev => prev.filter(t => t !== tag))}
           />
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              className={`${styles.refreshButton} ${viewType === 'SCRAP' ? styles.active : ''}`}
+              onClick={() => setViewType('SCRAP')}
+              title="스크랩 보기"
+            >
+              스크랩
+            </button>
+            <button
+              className={`${styles.refreshButton} ${viewType === 'UPLOAD' ? styles.active : ''}`}
+              onClick={() => setViewType('UPLOAD')}
+              title="업로드 보기"
+            >
+              업로드
+            </button>
+          </div>
           {isAuthenticated && (
             <Tooltip content="스크랩 목록 새로고침" side='bottom'>
               <button
@@ -688,55 +617,130 @@ const ScrapPage: React.FC = () => {
 
       <div className={styles.scrollableContent}>
         <div className={styles.scrapList}>
-          {scrapsLoading && scraps.length === 0 ? (
-            <div className={styles.loadingContainer}>
-              <div className={styles.loadingIndicator}>
-                스크랩 목록을 불러오는 중...
+          {viewType === 'SCRAP' ? (
+            scrapsLoading && scraps.length === 0 ? (
+              <div className={styles.loadingContainer}>
+                <div className={styles.loadingIndicator}>
+                  스크랩 목록을 불러오는 중...
+                </div>
               </div>
-            </div>
-          ) : scrapsError ? (
-            <div className={styles.errorContainer}>
-              <div className={styles.errorMessage}>
-                {scrapsError}
+            ) : scrapsError ? (
+              <div className={styles.errorContainer}>
+                <div className={styles.errorMessage}>
+                  {scrapsError}
+                </div>
+                <button 
+                  className={styles.retryButton}
+                  onClick={loadScraps}
+                >
+                  다시 시도
+                </button>
               </div>
-              <button 
-                className={styles.retryButton}
-                onClick={loadScraps}
-              >
-                다시 시도
-              </button>
-            </div>
-          ) : filteredScraps.length === 0 && selectedTags.length > 0 ? (
-            <div className={styles.emptyContainer}>
-              <div className={styles.emptyMessage}>
-                선택한 태그와 일치하는 스크랩이 없습니다.
+            ) : filteredScraps.length === 0 && selectedTags.length > 0 ? (
+              <div className={styles.emptyContainer}>
+                <div className={styles.emptyMessage}>
+                  선택한 태그와 일치하는 스크랩이 없습니다.
+                </div>
               </div>
-            </div>
-          ) : scraps.length === 0 ? (
-            <div className={styles.emptyContainer}>
-              <div className={styles.emptyMessage}>
-                아직 스크랩한 내용이 없습니다.
+            ) : scraps.length === 0 ? (
+              <div className={styles.emptyContainer}>
+                <div className={styles.emptyMessage}>
+                  아직 스크랩한 내용이 없습니다.
+                </div>
+                <div className={styles.emptySubMessage}>
+                  💡 위의 "페이지 스크랩" 버튼을 눌러 1초만에 스크랩하세요!
+                </div>
               </div>
-              <div className={styles.emptySubMessage}>
-                💡 위의 "페이지 스크랩" 버튼을 눌러 1초만에 스크랩하세요!
-              </div>
-            </div>
+            ) : (
+              filteredScraps.map((scrap) => (
+                <ScrapItem
+                  key={scrap.id} 
+                  scrap={scrap} 
+                  onDelete={async () => {
+                    try {
+                      await scrapService.deleteScrap(parseInt(scrap.id));
+                      await loadScraps();
+                      showSuccess('스크랩 삭제', '스크랩이 성공적으로 삭제되었습니다.');
+                    } catch (error: any) {
+                      showError('삭제 실패', error?.message || '스크랩 삭제에 실패했습니다.');
+                    }
+                  }}
+                />
+              ))
+            )
           ) : (
-            filteredScraps.map((scrap) => (
-            <ScrapItem
-              key={scrap.id} 
-              scrap={scrap} 
-              onDelete={async () => {
-                try {
-                  await scrapService.deleteScrap(parseInt(scrap.id));
-                  await loadScraps(); // 동기적으로 처리
-                  showSuccess('스크랩 삭제', '스크랩이 성공적으로 삭제되었습니다.');
-                } catch (error: any) {
-                  showError('삭제 실패', error?.message || '스크랩 삭제에 실패했습니다.');
-                }
-              }}
-            />
-          ))
+            uploadsLoading && uploads.length === 0 ? (
+              <div className={styles.loadingContainer}>
+                <div className={styles.loadingIndicator}>
+                  업로드 목록을 불러오는 중...
+                </div>
+              </div>
+            ) : uploadsError ? (
+              <div className={styles.errorContainer}>
+                <div className={styles.errorMessage}>
+                  {uploadsError}
+                </div>
+                <button 
+                  className={styles.retryButton}
+                  onClick={loadUploads}
+                >
+                  다시 시도
+                </button>
+              </div>
+            ) : uploads.length === 0 ? (
+              <div className={styles.emptyContainer}>
+                <div className={styles.emptyMessage}>
+                  아직 업로드한 PDF가 없습니다.
+                </div>
+              </div>
+            ) : (
+              uploads.map((item) => (
+                <div key={`upload-${item.id}`} className={styles.contentItem}>
+                  <div className={styles.contentHeader}>
+                    {item.url ? (
+                      <a href={item.url} target="_blank" rel="noreferrer" className={styles.contentTitle}>
+                        {item.title}
+                      </a>
+                    ) : (
+                      <div className={styles.contentTitle}>{item.title}</div>
+                    )}
+                    <Tooltip content="삭제" side='bottom'>
+                      <button
+                        onClick={async () => {
+                          try {
+                            await globalApiClient.delete(`/v1/uploaded-files/${item.id}`);
+                            await loadUploads();
+                            showSuccess('삭제 완료', '업로드가 삭제되었습니다.');
+                          } catch (e: any) {
+                            showError('삭제 실패', e?.message || '업로드 삭제에 실패했습니다.');
+                          }
+                        }}
+                        className={styles.deleteButton}
+                      >
+                        <IoTrash />
+                      </button>
+                    </Tooltip>
+                  </div>
+                  {item.description && (
+                    <div className={styles.contentDescription}>{item.description}</div>
+                  )}
+                  <div className={styles.contentFooter}>
+                    <div className={styles.tags}>
+                      {item.url ? (
+                        <a href={item.url} target="_blank" rel="noreferrer">파일 열기</a>
+                      ) : (
+                        'URL 없음'
+                      )}
+                    </div>
+                    {item.createdAt && (
+                      <div className={styles.contentDate}>
+                        {new Date(item.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))
+            )
           )}
         </div>
         {loading && (
@@ -747,6 +751,13 @@ const ScrapPage: React.FC = () => {
           </div>
         )}
       </div>
+
+      {/* PDF Upload Modal */}
+      <PDFUploadModal
+        isOpen={showPDFUploadModal}
+        onClose={() => setShowPDFUploadModal(false)}
+        onUploadSuccess={handlePDFUploadSuccess}
+      />
     </div>
   );
 };

--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { IoAdd, IoTrash, IoClose, IoClipboard, IoCheckmark, IoRefresh, IoDocument } from 'react-icons/io5';
+import { IoAdd, IoTrash, IoClose, IoClipboard, IoCheckmark, IoRefresh, IoDocument, IoLink } from 'react-icons/io5';
 import { browser } from 'wxt/browser';
 import styles from './PageStyles.module.css';
 import scrapStyles from './ScrapPage.module.css';
@@ -14,6 +14,7 @@ import { markdownToPlainTextPreview } from '../../utils/markdownConverter';
 import Tooltip from '../../components/common/Tooltip';
 import { PDFUploadModal } from '../../components/sidepanel/PDFUploadModal/PDFUploadModal';
 import { libraryItemService, type LibraryItemDto } from '../../services/libraryItemService';
+import { globalApiClient } from '../../services/globalApiClient';
 
 const ScrapPage: React.FC = () => {
   const { showSuccess, showError, showWarning } = useToastHelpers();
@@ -33,7 +34,8 @@ const ScrapPage: React.FC = () => {
   const [uploads, setUploads] = useState<LibraryItemDto[]>([]);
   const [uploadsLoading, setUploadsLoading] = useState(false);
   const [uploadsError, setUploadsError] = useState<string | null>(null);
-  const [viewType, setViewType] = useState<'SCRAP' | 'UPLOAD'>('SCRAP');
+  // createdAt timestamp map for scraps (ms since epoch)
+  const [scrapTimestamps, setScrapTimestamps] = useState<Record<string, number>>({});
   const observerRef = useRef<IntersectionObserver>();
   const lastScrapRef = useRef<HTMLDivElement>(null);
   const loadingTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
@@ -93,6 +95,12 @@ const ScrapPage: React.FC = () => {
       }));
       
       setScraps(convertedScraps);
+      // createdAt 타임스탬프 저장 (정렬용)
+      const tsMap: Record<string, number> = {};
+      for (const s of scrapList) {
+        tsMap[s.scrapId.toString()] = new Date(s.createdAt).getTime();
+      }
+      setScrapTimestamps(tsMap);
       // console.log('✅ Scraps state updated with', convertedScraps.length, 'items');
     } catch (error: any) {
       // console.error('❌ Failed to load scraps:', error);
@@ -190,26 +198,24 @@ const ScrapPage: React.FC = () => {
     checkAuthStatus();
   }, [checkAuthStatus]);
   
-  // 인증 상태가 변경되면 스크랩 목록 로드
+  // 인증 상태가 변경되면 목록 로드
   useEffect(() => {
     if (!isAuthenticated || !authChecked) {
       setScraps([]);
       setUploads([]);
       return;
     }
-    if (viewType === 'SCRAP') {
-      loadScraps();
-    } else {
-      loadUploads();
-    }
-  }, [isAuthenticated, authChecked, viewType, loadScraps, loadUploads]);
+    // 둘 다 로드
+    loadScraps();
+    loadUploads();
+  }, [isAuthenticated, authChecked, loadScraps, loadUploads]);
 
   // 페이지 visibility 변경 시 스크랩 목록 새로고침
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (!document.hidden && isAuthenticated && authChecked) {
-        if (viewType === 'SCRAP') loadScraps();
-        else loadUploads();
+        loadScraps();
+        loadUploads();
       }
     };
 
@@ -218,7 +224,7 @@ const ScrapPage: React.FC = () => {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [isAuthenticated, authChecked, viewType, loadScraps, loadUploads]);
+  }, [isAuthenticated, authChecked, loadScraps, loadUploads]);
 
   // Background script로부터 스크랩 생성 알림 수신
   useEffect(() => {
@@ -226,7 +232,7 @@ const ScrapPage: React.FC = () => {
     
     const handleScrapCreatedMessage = (message: any) => {
       if (isActive && message.action === 'scrapCreated' && isAuthenticated) {
-        if (viewType === 'SCRAP') loadScraps();
+        loadScraps();
       }
     };
 
@@ -235,7 +241,7 @@ const ScrapPage: React.FC = () => {
     return () => {
       isActive = false;
     };
-  }, [isAuthenticated, viewType, loadScraps]);
+  }, [isAuthenticated, loadScraps]);
 
   // 스크랩에 태그 추가
   const handleAddTag = useCallback(async (scrapId: string, tag: string) => {
@@ -319,6 +325,51 @@ const ScrapPage: React.FC = () => {
     }
   }, [scraps, loadScraps]);
 
+  // 업로드에 태그 추가
+  const handleAddUploadTag = useCallback(async (itemId: number, tag: string) => {
+    if (!tag.trim() || isAddingTag) return;
+    try {
+      setIsAddingTag(true);
+      await libraryItemService.addTag(itemId, 'UPLOAD', tag.trim());
+      await loadUploads();
+      setActiveInputId(null);
+    } catch (error: any) {
+      showError('태그 추가 실패', `${error.message || '알 수 없는 오류'}`);
+      if (error.message?.includes('Authentication')) setIsAuthenticated(false);
+    } finally {
+      setIsAddingTag(false);
+    }
+  }, [isAddingTag, loadUploads, showError]);
+
+  // 업로드에서 태그 삭제
+  const handleRemoveUploadTag = useCallback(async (itemId: number, tagName: string) => {
+    try {
+      const tags = await libraryItemService.getTags(itemId, 'UPLOAD');
+      const tag = tags.find(t => t.name === tagName);
+      if (!tag) throw new Error('삭제할 태그를 찾을 수 없습니다.');
+      await libraryItemService.removeTag(itemId, 'UPLOAD', tag.tagId);
+      await loadUploads();
+    } catch (error: any) {
+      showError('태그 삭제 실패', `${error.message || '알 수 없는 오류'}`);
+      if (error.message?.includes('Authentication')) setIsAuthenticated(false);
+    }
+  }, [loadUploads, showError]);
+
+  // 업로드 태그 입력 키 핸들러
+  const handleUploadKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>, itemId: number) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const tagValue = e.currentTarget.value.trim();
+      if (tagValue) {
+        handleAddUploadTag(itemId, tagValue);
+        e.currentTarget.value = '';
+      }
+    } else if (e.key === 'Escape') {
+      setActiveInputId(null);
+      e.currentTarget.value = '';
+    }
+  }, [handleAddUploadTag]);
+
   // 키보드 입력 처리
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>, scrapId: string) => {
     if (e.key === 'Enter') {
@@ -341,25 +392,37 @@ const ScrapPage: React.FC = () => {
     
     try {
       setIsRefreshing(true);
-      if (viewType === 'SCRAP') {
-        await loadScraps();
-        showSuccess('새로고침 완료', '스크랩 목록이 업데이트되었습니다.');
-      } else {
-        await loadUploads();
-        showSuccess('새로고침 완료', '업로드 목록이 업데이트되었습니다.');
-      }
+      await Promise.all([loadScraps(), loadUploads()]);
+      showSuccess('새로고침 완료', '목록이 업데이트되었습니다.');
     } catch (error: any) {
       showError('새로고침 실패', error.message || '목록 새로고침에 실패했습니다.');
     } finally {
       setIsRefreshing(false);
     }
-  }, [isAuthenticated, isRefreshing, viewType, loadScraps, loadUploads, showSuccess, showError]);
+  }, [isAuthenticated, isRefreshing, loadScraps, loadUploads, showSuccess, showError]);
 
   // PDF 업로드 성공 시 처리
   const handlePDFUploadSuccess = useCallback(() => {
-    if (viewType === 'SCRAP') loadScraps();
-    else loadUploads();
-  }, [viewType, loadScraps, loadUploads]);
+    // 업로드 성공 시 업로드 목록을 갱신
+    loadUploads();
+  }, [loadUploads]);
+
+  // 스크랩과 업로드를 합친 통합 목록 (최신순)
+  const combinedItems = useMemo(() => {
+    type Combined = { type: 'SCRAP' | 'UPLOAD'; ts: number; key: string; scrap?: Scrap; upload?: LibraryItemDto };
+    const items: Combined[] = [];
+    // 스크랩: 태그 필터 적용된 것만 포함
+    for (const s of filteredScraps) {
+      const ts = scrapTimestamps[s.id] ?? new Date(s.date).getTime();
+      items.push({ type: 'SCRAP', ts, key: `scrap-${s.id}`, scrap: s });
+    }
+    // 업로드: 항상 포함
+    for (const u of uploads) {
+      const ts = u.createdAt ? new Date(u.createdAt).getTime() : 0;
+      items.push({ type: 'UPLOAD', ts, key: `upload-${u.id}`, upload: u });
+    }
+    return items.sort((a, b) => b.ts - a.ts);
+  }, [filteredScraps, uploads, scrapTimestamps]);
 
   // 로그인 페이지로 이동 (또는 로그아웃 처리)
   const handleLogin = useCallback(async () => {
@@ -450,6 +513,7 @@ const ScrapPage: React.FC = () => {
       <div className={styles.contentItem} data-url={scrap.url}>
         <div className={styles.contentHeader}>
           <a href={scrap.url} target="_blank" rel="noopener noreferrer" className={styles.contentTitle}>
+            <IoLink size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
             {scrap.title}
           </a>
           <Tooltip content="삭제" side='bottom'>
@@ -585,22 +649,6 @@ const ScrapPage: React.FC = () => {
             )}
             onTagRemove={(tag) => setSelectedTags(prev => prev.filter(t => t !== tag))}
           />
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button
-              className={`${styles.refreshButton} ${viewType === 'SCRAP' ? styles.active : ''}`}
-              onClick={() => setViewType('SCRAP')}
-              title="스크랩 보기"
-            >
-              스크랩
-            </button>
-            <button
-              className={`${styles.refreshButton} ${viewType === 'UPLOAD' ? styles.active : ''}`}
-              onClick={() => setViewType('UPLOAD')}
-              title="업로드 보기"
-            >
-              업로드
-            </button>
-          </div>
           {isAuthenticated && (
             <Tooltip content="스크랩 목록 새로고침" side='bottom'>
               <button
@@ -617,131 +665,163 @@ const ScrapPage: React.FC = () => {
 
       <div className={styles.scrollableContent}>
         <div className={styles.scrapList}>
-          {viewType === 'SCRAP' ? (
-            scrapsLoading && scraps.length === 0 ? (
-              <div className={styles.loadingContainer}>
-                <div className={styles.loadingIndicator}>
-                  스크랩 목록을 불러오는 중...
+          {(() => {
+            const isInitialLoading = (scrapsLoading || uploadsLoading) && combinedItems.length === 0;
+            const hasError = !!scrapsError || !!uploadsError;
+            if (isInitialLoading) {
+              return (
+                <div className={styles.loadingContainer}>
+                  <div className={styles.loadingIndicator}>목록을 불러오는 중...</div>
                 </div>
-              </div>
-            ) : scrapsError ? (
-              <div className={styles.errorContainer}>
-                <div className={styles.errorMessage}>
-                  {scrapsError}
-                </div>
-                <button 
-                  className={styles.retryButton}
-                  onClick={loadScraps}
-                >
-                  다시 시도
-                </button>
-              </div>
-            ) : filteredScraps.length === 0 && selectedTags.length > 0 ? (
-              <div className={styles.emptyContainer}>
-                <div className={styles.emptyMessage}>
-                  선택한 태그와 일치하는 스크랩이 없습니다.
-                </div>
-              </div>
-            ) : scraps.length === 0 ? (
-              <div className={styles.emptyContainer}>
-                <div className={styles.emptyMessage}>
-                  아직 스크랩한 내용이 없습니다.
-                </div>
-                <div className={styles.emptySubMessage}>
-                  💡 위의 "페이지 스크랩" 버튼을 눌러 1초만에 스크랩하세요!
-                </div>
-              </div>
-            ) : (
-              filteredScraps.map((scrap) => (
-                <ScrapItem
-                  key={scrap.id} 
-                  scrap={scrap} 
-                  onDelete={async () => {
-                    try {
-                      await scrapService.deleteScrap(parseInt(scrap.id));
-                      await loadScraps();
-                      showSuccess('스크랩 삭제', '스크랩이 성공적으로 삭제되었습니다.');
-                    } catch (error: any) {
-                      showError('삭제 실패', error?.message || '스크랩 삭제에 실패했습니다.');
-                    }
-                  }}
-                />
-              ))
-            )
-          ) : (
-            uploadsLoading && uploads.length === 0 ? (
-              <div className={styles.loadingContainer}>
-                <div className={styles.loadingIndicator}>
-                  업로드 목록을 불러오는 중...
-                </div>
-              </div>
-            ) : uploadsError ? (
-              <div className={styles.errorContainer}>
-                <div className={styles.errorMessage}>
-                  {uploadsError}
-                </div>
-                <button 
-                  className={styles.retryButton}
-                  onClick={loadUploads}
-                >
-                  다시 시도
-                </button>
-              </div>
-            ) : uploads.length === 0 ? (
-              <div className={styles.emptyContainer}>
-                <div className={styles.emptyMessage}>
-                  아직 업로드한 PDF가 없습니다.
-                </div>
-              </div>
-            ) : (
-              uploads.map((item) => (
-                <div key={`upload-${item.id}`} className={styles.contentItem}>
-                  <div className={styles.contentHeader}>
-                    {item.url ? (
-                      <a href={item.url} target="_blank" rel="noreferrer" className={styles.contentTitle}>
-                        {item.title}
-                      </a>
-                    ) : (
-                      <div className={styles.contentTitle}>{item.title}</div>
-                    )}
-                    <Tooltip content="삭제" side='bottom'>
-                      <button
-                        onClick={async () => {
-                          try {
-                            await globalApiClient.delete(`/v1/uploaded-files/${item.id}`);
-                            await loadUploads();
-                            showSuccess('삭제 완료', '업로드가 삭제되었습니다.');
-                          } catch (e: any) {
-                            showError('삭제 실패', e?.message || '업로드 삭제에 실패했습니다.');
-                          }
-                        }}
-                        className={styles.deleteButton}
-                      >
-                        <IoTrash />
-                      </button>
-                    </Tooltip>
+              );
+            }
+            if (hasError && combinedItems.length === 0) {
+              return (
+                <div className={styles.errorContainer}>
+                  <div className={styles.errorMessage}>
+                    {scrapsError || uploadsError}
                   </div>
-                  {item.description && (
-                    <div className={styles.contentDescription}>{item.description}</div>
-                  )}
-                  <div className={styles.contentFooter}>
-                    <div className={styles.tags}>
-                      {item.url ? (
-                        <a href={item.url} target="_blank" rel="noreferrer">파일 열기</a>
+                  <button className={styles.retryButton} onClick={handleRefresh}>다시 시도</button>
+                </div>
+              );
+            }
+            if (combinedItems.length === 0) {
+              return (
+                <div className={styles.emptyContainer}>
+                  <div className={styles.emptyMessage}>아직 스크랩 또는 업로드가 없습니다.</div>
+                </div>
+              );
+            }
+            return combinedItems.map((item) => {
+              if (item.type === 'SCRAP' && item.scrap) {
+                const scrap = item.scrap;
+                return (
+                  <ScrapItem
+                    key={item.key}
+                    scrap={scrap}
+                    onDelete={async () => {
+                      try {
+                        await scrapService.deleteScrap(parseInt(scrap.id));
+                        await loadScraps();
+                        showSuccess('스크랩 삭제', '스크랩이 성공적으로 삭제되었습니다.');
+                      } catch (error: any) {
+                        showError('삭제 실패', error?.message || '스크랩 삭제에 실패했습니다.');
+                      }
+                    }}
+                  />
+                );
+              }
+              if (item.type === 'UPLOAD' && item.upload) {
+                const u = item.upload;
+                return (
+                  <div key={item.key} className={styles.contentItem}>
+                    <div className={styles.contentHeader}>
+                      {u.url ? (
+                        <a href={u.url} target="_blank" rel="noreferrer" className={styles.contentTitle}>
+                          <IoDocument size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
+                          {u.title}
+                        </a>
                       ) : (
-                        'URL 없음'
+                        <div className={styles.contentTitle}>
+                          <IoDocument size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
+                          {u.title}
+                        </div>
+                      )}
+                      <Tooltip content="삭제" side='bottom'>
+                        <button
+                          onClick={async () => {
+                            // 낙관적 업데이트: 즉시 UI에서 항목 제거
+                            const prevUploads = uploads;
+                            setUploads((curr) => curr.filter((it) => it.id !== u.id));
+                            try {
+                              await globalApiClient.delete(`/v1/uploaded-files/${u.id}`);
+                              showSuccess('삭제 완료', '업로드가 삭제되었습니다.');
+                              // 백그라운드에서 최신 목록 동기화
+                              // void loadUploads();
+                            } catch (e: any) {
+                              // 실패 시 롤백
+                              setUploads(prevUploads);
+                              showError('삭제 실패', e?.message || '업로드 삭제에 실패했습니다.');
+                            }
+                          }}
+                          className={styles.deleteButton}
+                        >
+                          <IoTrash />
+                        </button>
+                      </Tooltip>
+                    </div>
+                    {u.description && (
+                      <div className={styles.contentDescription}>{u.description}</div>
+                    )}
+                    <div className={styles.contentFooter}>
+                      <div className={styles.tags}>
+                        <button 
+                          className={styles.addTagButton}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            const key = `upload-${u.id}`;
+                            setActiveInputId(activeInputId === key ? null : key);
+                            setShowAllTags(null);
+                          }}
+                        >
+                          <IoAdd size={14} />
+                        </button>
+                        <TagList 
+                          tags={u.tags || []}
+                          maxVisibleTags={2}
+                          onTagRemove={(tagName) => handleRemoveUploadTag(u.id, tagName)}
+                          showRemoveButton={true}
+                        />
+                        {activeInputId === `upload-${u.id}` && (
+                          <div 
+                            className={styles.tagInputTooltip} 
+                            data-tooltip-id={`upload-${u.id}`}
+                          >
+                            <input
+                              ref={inputRef}
+                              type="text"
+                              onKeyDown={(e) => handleUploadKeyDown(e, u.id)}
+                              placeholder="태그 입력 후 Enter"
+                              className={styles.tagInput}
+                              autoFocus
+                            />
+                            <button 
+                              className={styles.tagSubmitButton}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                const inputElement = inputRef.current;
+                                if (inputElement) {
+                                  const tagValue = inputElement.value.trim();
+                                  if (tagValue) {
+                                    handleAddUploadTag(u.id, tagValue);
+                                    inputElement.value = '';
+                                  }
+                                }
+                              }}
+                            >
+                              추가
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                      {u.createdAt && (
+                        <div className={styles.contentDate}>
+                          {new Date(u.createdAt).toLocaleString('ko-KR', {
+                            year: 'numeric',
+                            month: '2-digit',
+                            day: '2-digit',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </div>
                       )}
                     </div>
-                    {item.createdAt && (
-                      <div className={styles.contentDate}>
-                        {new Date(item.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })}
-                      </div>
-                    )}
                   </div>
-                </div>
-              ))
-            )
-          )}
+                );
+              }
+              return null;
+            });
+          })()}
         </div>
         {loading && (
           <div className={styles.loadingContainer}>


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-287](https://linear.app/chill-mato/issue/CHI-287/)

## 변경 요약
<!-- 주요 변경사항을 한두 줄로 요약해주세요 -->
- 업로드 파일 카드 UI 개선
  - 업로드 파일도 스크랩과 동일한 날짜 포맷(연-월-일 시) 표시
 - 삭제 버튼 제공 + 삭제 성공/실패 토스트 알림 표시
- 삭제 UX 성능 개선
  - 낙관적 업데이트 적용: 삭제 클릭 시 즉시 목록에서 제거 → 백그라운드로 서버 삭제 → 실패 시 롤백
- 에러 개선
  - 업로드 삭제 시 빈 응답 본문으로 인한 JSON 파싱 에러 방지(서버 삭제 응답 본문 반환으로 해결)

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 스크린샷/데모 (선택)
<!-- UI 변경/신규 기능이 있다면 첨부 -->
<img width="400" height="1009" alt="image" src="https://github.com/user-attachments/assets/babcf7ad-00bc-4fa4-80ef-b2dbfa9ffd8b" />
<br>
<img width="395" height="994" alt="스크린샷 2025-09-03 오후 6 17 46" src="https://github.com/user-attachments/assets/3160236b-5ed0-4343-b1f5-8b81483cc826" />
<br>
<img width="315" height="226" alt="스크린샷 2025-09-03 오후 6 18 02" src="https://github.com/user-attachments/assets/a62cdc67-f359-4621-980e-a379bb1436fe" />
<br>

### 아이콘으로 자료 분류
- 링크: 스크랩
- 파일: pdf

## 기타 참고사항
<!-- 리뷰어가 중점적으로 봐야 할 부분, 추가 설명 등 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * PDF upload modal with drag-and-drop or file picker, title/description inputs, 50MB limit, loading state, and success/error toasts.
  * Uploaded files now appear alongside scraps in a single, time‑sorted list; auto-refresh after successful upload.
  * Manage tags on uploads (add/remove) and delete uploaded files with immediate UI feedback.
  * Responsive modal styling for smaller screens.

* Improvements
  * Clearer loading/error messages (Korean) and more reliable upload handling.
  * Scrap items now show a link icon for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->