### PR TITLE
[CHI-289] 스크랩 상세 페이지 UI 구현 및 마크다운 파싱 개선

### DIFF
--- a/.wxt/types/paths.d.ts
+++ b/.wxt/types/paths.d.ts
@@ -15,6 +15,7 @@ declare module "wxt/browser" {
     | "/icon48.png"
     | "/options.html"
     | "/sidepanel.html"
+    | "/webscrapviewer.html"
   type HtmlPublicPath = Extract<PublicPath, `${string}.html`>
   export interface WxtRuntime {
     getURL(path: PublicPath): string;

--- a/entrypoints/webscrapviewer/index.html
+++ b/entrypoints/webscrapviewer/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tyquill Web Scrap Viewer</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+</body>
+</html>
+
+

--- a/entrypoints/webscrapviewer/main.tsx
+++ b/entrypoints/webscrapviewer/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import ViewerApp from '../../src/viewer/App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<ViewerApp />);
+}
+
+

--- a/src/components/sidepanel/ExportButton/ExportButton.tsx
+++ b/src/components/sidepanel/ExportButton/ExportButton.tsx
@@ -138,11 +138,15 @@ const ExportButton: React.FC<ExportButtonProps> = ({ title, content }) => {
 
               const processTextFormatting = (text: string) => {
                 return text
-                  .replace(/\*\*(.*?)\*\*/g, '<b>$1</b>')
-                  .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<i>$1</i>')
-                  .replace(/~~(.*?)~~/g, '<del>$1</del>')
-                  .replace(/__([^_]+)__/g, '<u>$1</u>')
-                  .replace(/`([^`]+)`/g, '<code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 3px; font-family: monospace;">$1</code>');
+                  // 이미지: ![alt](url "title") → <img class="image-tool__image-picture" src="url">
+                  .replace(/!\[[^\]]*\]\(\s*([^\)\s]+)(?:\s+\"[^\"]*\")?\s*\)/g, '<img class="image-tool__image-picture" src="$1">')
+                  // 링크: [text](url) → <a href="url" target="_blank">url</a>
+                  .replace(/\[[^\]]+\]\(\s*([^\)]+?)\s*\)/g, '<a href="$1" target="_blank">$1<\/a>')
+                  .replace(/\*\*(.*?)\*\*/g, '<b>$1<\/b>')
+                  .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<i>$1<\/i>')
+                  .replace(/~~(.*?)~~/g, '<del>$1<\/del>')
+                  .replace(/__([^_]+)__/g, '<u>$1<\/u>')
+                  .replace(/`([^`]+)`/g, '<code style=\"background-color: #f0f0f0; padding: 2px 4px; border-radius: 3px; font-family: monospace;\">$1<\/code>');
               };
 
               while (i < lines.length) {

--- a/src/services/scrapService.ts
+++ b/src/services/scrapService.ts
@@ -136,6 +136,20 @@ export class ScrapService {
   }
 
   /**
+   * 스크랩 단건 조회
+   */
+  async getScrapById(scrapId: number): Promise<ScrapResponse> {
+    try {
+      const response = await this.apiRequest<ScrapResponse>(`/v1/scraps/${scrapId}`, {
+        method: 'GET',
+      });
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
    * 스크랩 삭제
    */
   async deleteScrap(scrapId: number): Promise<void> {

--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -508,16 +508,30 @@ const ScrapPage: React.FC = () => {
 
 
 
+  const openScrapInNewTab = useCallback(async (scrapId: string) => {
+    try {
+      const url = browser.runtime.getURL(`/webscrapviewer.html#scrapId=${scrapId}`);
+      await browser.tabs.create({ url });
+    } catch (e) {
+      showError('새 탭 열기 실패', '스크랩 뷰어를 여는 중 오류가 발생했습니다.');
+    }
+  }, [showError]);
+
   const ScrapItem = React.memo<{ scrap: Scrap; onDelete: () => void }>(({ scrap, onDelete }) => {
     return (
-      <div className={styles.contentItem} data-url={scrap.url}>
+      <div 
+        className={styles.contentItem} 
+        data-url={scrap.url}
+        onClick={() => openScrapInNewTab(scrap.id)}
+        style={{ cursor: 'pointer' }}
+      >
         <div className={styles.contentHeader}>
-          <a href={scrap.url} target="_blank" rel="noopener noreferrer" className={styles.contentTitle}>
+          <a href={scrap.url} target="_blank" rel="noopener noreferrer" className={styles.contentTitle} onClick={(e) => e.stopPropagation()}>
             <IoLink size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
             {scrap.title}
           </a>
           <Tooltip content="삭제" side='bottom'>
-            <button onClick={onDelete} className={styles.deleteButton}>
+            <button onClick={(e) => { e.stopPropagation(); onDelete(); }} className={styles.deleteButton}>
               <IoTrash />
             </button>
           </Tooltip>

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -11,6 +11,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className 
   // 볼드/이탤릭/취소선 텍스트 처리 헬퍼 함수 (개선된 패턴)
   const processTextFormatting = (text: string) => {
     return text
+      // 이미지 처리: ![alt](url "optional title") → <img>
+      .replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, '<img src="$2" alt="$1" style="max-width: 100%; height: auto; display: inline-block;" />')
       // 볼드 처리: **text** (한글과 특수문자 포함하여 더 넓게 매칭)
       .replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>')
       // 이탤릭 처리: *text* (볼드와 겹치지 않도록 개선)
@@ -26,7 +28,20 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className 
   };
 
   const renderMarkdown = (markdown: string) => {
-    const lines = markdown.split('\n');
+    // 멀티라인 링크/이미지 구문을 먼저 HTML로 치환하여 줄 단위 파싱 한계를 보완
+    const normalized = markdown
+      // 멀티라인 이미지: ![alt...\n\n...](url)
+      .replace(/!\[([\s\S]*?)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g, (_m, alt: string, url: string) => {
+        const collapsedAlt = (alt as string).replace(/\s+/g, ' ').trim();
+        return `<img src="${url}" alt="${collapsedAlt}" style="max-width: 100%; height: auto; display: inline-block;" />`;
+      })
+      // 멀티라인 링크: [text...\n\n...](url)
+      .replace(/\[([\s\S]*?)\]\(\s*([^\)]+?)\s*\)/g, (_m, text: string, url: string) => {
+        const collapsedText = (text as string).replace(/\s+/g, ' ').trim();
+        return `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: #0066cc; text-decoration: underline;">${collapsedText}</a>`;
+      });
+
+    const lines = normalized.split('\n');
     const elements: React.ReactElement[] = [];
     let key = 0;
     let i = 0;

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { scrapService } from '../services/scrapService';
+import MarkdownRenderer from '../utils/markdownRenderer';
+
+interface ScrapData {
+  title: string;
+  content: string;
+  url: string;
+  createdAt?: string;
+}
+
+const getScrapIdFromHash = (): string | null => {
+  const hash = window.location.hash.replace(/^#/, '');
+  const params = new URLSearchParams(hash);
+  return params.get('scrapId');
+};
+
+const App: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [scrap, setScrap] = useState<ScrapData | null>(null);
+
+  const scrapId = useMemo(() => getScrapIdFromHash(), []);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!scrapId) {
+        setError('유효하지 않은 스크랩 ID');
+        setLoading(false);
+        return;
+      }
+      try {
+        const data = await scrapService.getScrapById(parseInt(scrapId, 10));
+        setScrap({ title: data.title, content: data.content, url: data.url, createdAt: data.createdAt });
+      } catch (e: any) {
+        setError(e?.message || '스크랩을 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [scrapId]);
+
+  if (loading) return <div style={{ padding: 16 }}>불러오는 중...</div>;
+  if (error) return <div style={{ padding: 16, color: 'red' }}>{error}</div>;
+  if (!scrap) return <div style={{ padding: 16 }}>데이터가 없습니다.</div>;
+
+  return (
+    <div style={{ maxWidth: 860, margin: '0 auto', padding: 24 }}>
+      <h1 style={{ fontSize: 24, marginBottom: 8 }}>{scrap.title}</h1>
+      <div style={{ marginBottom: 16, color: '#666' }}>
+        <a href={scrap.url} target="_blank" rel="noreferrer">원문 링크</a>
+        {scrap.createdAt && (
+          <span style={{ marginLeft: 12 }}>
+            {new Date(scrap.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
+          </span>
+        )}
+      </div>
+      <MarkdownRenderer content={scrap.content} />
+    </div>
+  );
+};
+
+export default App;
+
+

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     permissions: [
       'storage',
       'sidePanel',
+      'tabs',
       'activeTab',
       'scripting',
       'contextMenus'
@@ -26,6 +27,14 @@ export default defineConfig({
     side_panel: {
       default_path: 'sidepanel.html'
     },
+    web_accessible_resources: [
+      {
+        resources: [
+          'webscrapviewer.html'
+        ],
+        matches: ['<all_urls>']
+      }
+    ],
     action: {
       default_title: 'Open Tyquill Side Panel',
       default_icon: {


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-289](https://linear.app/chill-mato/issue/CHI-289/)

## 변경 요약
사이드패널 스크랩 클릭 시 확장 프로그램 내부 페이지에서 스크랩을 열도록 하고, 복사/내보내기 시 마크다운의 링크/이미지를 HTML로 정확히 변환합니다.

## 주요 변경사항
- 내부 뷰어 추가 및 연결
  - `entrypoints/webscrapviewer/` 엔트리포인트 추가: `index.html`, `main.tsx`
  - `src/viewer/App.tsx`: `#scrapId` 해시 파싱 후 `scrapService.getScrapById`로 데이터 조회 및 렌더
  - `src/sidepanel/pages/ScrapPage.tsx`: 스크랩 카드 클릭 시 `chrome-extension://.../webscrapviewer.html#scrapId=...` 새 탭 오픈
  - `wxt.config.ts`: `tabs` 권한 추가, `web_accessible_resources`에 `webscrapviewer.html` 등록
- 마크다운 → HTML 렌더(클립보드 복사용) 개선
  - `src/utils/markdownRenderer.tsx`:
    - `![alt](url)` → `<img src="url" style="max-width:100%; height:auto">`
    - `[text](url)` → `<a href="url" target="_blank" rel="noopener noreferrer">text</a>`
    - 멀티라인 `[text ...](url)` / `![alt ...](url)`도 안전 처리
- 내보내기(Export → maily) 포맷 지정
  - `src/components/sidepanel/ExportButton/ExportButton.tsx` 인젝션 변환 로직 보강:
    - `[]()` 링크 → `<a href="URL" target="_blank">URL</a>`
    - `![]()` 이미지 → `<img class="image-tool__image-picture" src="URL">`
- API 보강
  - `src/services/scrapService.ts`: `getScrapById(scrapId: number)` 추가

## 테스트
- [ ] 빌드 확인
- [ ] 주요 기능 정상 동작 확인
  - [ ] 스크랩 카드 클릭 시 새 탭에서 웹 스크랩 뷰어 열림
  - [ ] 뷰어에서 스크랩 본문, 원문 링크, 작성일 정상 표시
  - [ ] 복사 시 a/img 태그로 HTML 복사됨
  - [ ] 내보내기 시 maily 요구 포맷으로 링크/이미지 삽입됨

## 스크린샷/데모 (선택)
<!-- 필요 시 추가 -->

## 기타 참고사항
- 확장 프로그램 권한(`tabs`) 및 `web_accessible_resources` 변경으로 브라우저에서 확장 프로그램 재로딩 필요
- 기존 `viewer` 엔트리포인트는 `webscrapviewer`로 대체
- **Scrap API가 변경되면 관련 타입 및 페이지 UI를 변경해야 합니다. 또한, 제목이 두 번 나오는 문제를 수정하고, 각종 UI를 수정해야 한 이후 배포해야 합니다.**

