### PR TITLE
[CHI-306] 스크랩 로직 및 뷰어 UI 개선

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -155,7 +155,7 @@ export default defineBackground(() => {
       // Content Script로 클리핑 요청
       const response = await browser.tabs.sendMessage(tabId, {
         type: 'CLIP_PAGE',
-        options: { includeMetadata: true }
+        options: { includeMetadata: false }
       });
 
       if (!response.success) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -154,7 +154,7 @@ async function handleClipAndScrapCurrentPage(sender: Browser.runtime.MessageSend
     // Content Script로 클리핑 요청
     const response = await browser.tabs.sendMessage(tabId, {
       type: 'CLIP_PAGE',
-      options: { includeMetadata: true }
+      options: { includeMetadata: false }
     });
 
     if (!response.success) {
@@ -238,7 +238,7 @@ async function handleClipCurrentPageForStyle(sender: Browser.runtime.MessageSend
     // Content Script로 클리핑 요청
     const response = await browser.tabs.sendMessage(tabId, {
       type: 'CLIP_PAGE',
-      options: { includeMetadata: true }
+      options: { includeMetadata: false }
     });
 
     if (!response.success) {

--- a/src/sidepanel/pages/PageStyles.module.css
+++ b/src/sidepanel/pages/PageStyles.module.css
@@ -457,20 +457,30 @@
   margin-bottom: 8px;
 }
 
-.contentTitle {
-  font-size: 16px;
-  font-weight: 600;
-  color: #1a1a1a;
-  text-decoration: none;
+.contentTitleWrapper {
+  display: flex;
+  align-items: center;
   flex: 1;
+  min-width: 0;
   margin-right: 12px;
-  line-height: 1.4;
+}
+
+.titleText {
+  display: inline-block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.contentTitle:hover {
+.contentTitleLink {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
+.contentTitleLink:hover {
   text-decoration: underline;
 }
 

--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -526,10 +526,14 @@ const ScrapPage: React.FC = () => {
         style={{ cursor: 'pointer' }}
       >
         <div className={styles.contentHeader}>
-          <a href={scrap.url} target="_blank" rel="noopener noreferrer" className={styles.contentTitle} onClick={(e) => e.stopPropagation()}>
+          <div className={styles.contentTitleWrapper}>
             <IoLink size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
-            {scrap.title}
-          </a>
+            <span className={styles.titleText}>
+              <a href={scrap.url} target="_blank" rel="noopener noreferrer" className={styles.contentTitleLink} onClick={(e) => e.stopPropagation()}>
+                {scrap.title}
+              </a>
+            </span>
+          </div>
           <Tooltip content="삭제" side='bottom'>
             <button onClick={(e) => { e.stopPropagation(); onDelete(); }} className={styles.deleteButton}>
               <IoTrash />
@@ -745,14 +749,18 @@ const ScrapPage: React.FC = () => {
                   >
                     <div className={styles.contentHeader}>
                       {u.url ? (
-                        <a href={u.url} target="_blank" rel="noreferrer" className={styles.contentTitle} onClick={(e) => e.stopPropagation()}>
+                        <div className={styles.contentTitleWrapper}>
                           <IoDocument size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
-                          {u.title}
-                        </a>
+                          <span className={styles.titleText}>
+                            <a href={u.url} target="_blank" rel="noreferrer" className={styles.contentTitleLink} onClick={(e) => e.stopPropagation()}>
+                              {u.title}
+                            </a>
+                          </span>
+                        </div>
                       ) : (
-                        <div className={styles.contentTitle}>
+                        <div className={styles.contentTitleWrapper}>
                           <IoDocument size={16} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
-                          {u.title}
+                          <span className={styles.titleText}>{u.title}</span>
                         </div>
                       )}
                       <Tooltip content="삭제" side='bottom'>

--- a/src/sidepanel/pages/ScrapPage.tsx
+++ b/src/sidepanel/pages/ScrapPage.tsx
@@ -537,7 +537,7 @@ const ScrapPage: React.FC = () => {
           </Tooltip>
         </div>
         <div className={styles.contentDescription}>
-          {markdownToPlainTextPreview(scrap.content)}
+          {scrap.content}
         </div>
         <div className={styles.contentFooter}>
           <div className={styles.tags}>

--- a/src/utils/webClipper.ts
+++ b/src/utils/webClipper.ts
@@ -157,6 +157,12 @@ export class WebClipper {
       '.markdown-body', // GitHub 등
       '.post', // 블로그
       '.story-body', // 뉴스
+      // CMS/빌더/메일 본문 컨테이너들
+      '.et_pb_post_content', // Divi (WordPress)
+      '.mail_view_contents_inner', // NAVER Mail 본문
+      '.mail_view_contents',
+      '[itemprop="articleBody"]',
+      '[data-article-body]'
     ];
 
     for (const selector of contentSelectors) {
@@ -177,7 +183,7 @@ export class WebClipper {
     const text = element.textContent?.trim() || '';
     const wordCount = text.split(/\s+/).length;
     
-    // 최소 50단어 이상 && 네비게이션/사이드바가 아님
+    // 포함 우선: 링크 밀도는 점수에서 페널티 처리하므로 여기서는 배제하지 않음
     return wordCount > 50 && !this.isNavigationElement(element);
   }
 
@@ -188,7 +194,7 @@ export class WebClipper {
     const className = element.className.toLowerCase();
     const tagName = element.tagName.toLowerCase();
     
-    const navKeywords = ['nav', 'menu', 'sidebar', 'header', 'footer', 'aside'];
+    const navKeywords = ['nav', 'menu', 'sidebar', 'header', 'footer', 'aside', 'gnb', 'lnb', 'breadcrumb'];
     
     return navKeywords.some(keyword => 
       className.includes(keyword) || 
@@ -207,7 +213,7 @@ export class WebClipper {
 
     for (const element of candidates) {
       const score = this.calculateContentScore(element);
-      if (score > maxScore && score > 100) {
+      if (score > maxScore) {
         maxScore = score;
         bestElement = element;
       }
@@ -224,16 +230,42 @@ export class WebClipper {
     const wordCount = text.split(/\s+/).length;
     const paragraphs = element.querySelectorAll('p').length;
     const headings = element.querySelectorAll('h1, h2, h3, h4, h5, h6').length;
-    
-    // 점수 계산 (단어 수 + 문단 수 * 10 + 헤딩 수 * 5)
-    let score = wordCount + (paragraphs * 10) + (headings * 5);
-    
-    // 네비게이션 요소면 점수 감점
-    if (this.isNavigationElement(element)) {
-      score *= 0.1;
+    const links = element.querySelectorAll('a').length;
+    const linkDensity = paragraphs > 0 ? links / Math.max(paragraphs, 1) : (links > 0 ? links : 0);
+
+    // 기본 점수 (문단 가중치 상향)
+    let score = wordCount + (paragraphs * 15) + (headings * 5);
+
+    // 본문 힌트 보너스
+    if (this.matchesContentHint(element)) {
+      score += 300;
     }
-    
+
+    // 네비게이션 요소면 큰 감점
+    if (this.isNavigationElement(element)) {
+      score *= 0.2;
+    }
+
+    // 링크 밀도 페널티
+    if (linkDensity > 0) {
+      score = score / (1 + Math.min(linkDensity, 5));
+    }
+
     return score;
+  }
+
+  /**
+   * 본문 컨테이너 힌트 매칭
+   */
+  private matchesContentHint(element: Element): boolean {
+    const el = element as HTMLElement;
+    const cls = `${el.className || ''}`.toLowerCase();
+    const id = `${el.id || ''}`.toLowerCase();
+    const hints = [
+      'article', 'content', 'post', 'entry', 'markdown-body',
+      'et_pb_post_content', 'mail_view_contents_inner', 'mail_view_contents',
+    ];
+    return hints.some(h => cls.includes(h) || id.includes(h));
   }
 
   /**
@@ -259,12 +291,43 @@ export class WebClipper {
       '.social-share',
       '.comments',
       '.related-posts',
+      // 쿠키/배너/모달/팝업/툴팁 등 비-본문 공통 요소
+      '[role="dialog"]',
+      '.modal',
+      '.popup',
+      '.popover',
+      '.tooltip',
+      '[data-nosnippet]',
+      '[aria-hidden="true"]',
+      // 컨센트/쿠키 배너 패턴
+      '[class*="cookie"]',
+      '[id*="cookie"]',
+      '[class*="consent"]',
+      '[id*="consent"]',
+      '.osano-cm-window',
+      // 글로벌 네비게이션/헤더
+      '#gnb',
+      '#pc_header',
+      '.gnb',
+      '.lnb',
+      // 기타 본문 외 위젯/배너
+      '[class*="subscribe"]',
+      '[class*="newsletter"]',
+      '[class*="signup"]',
+      '[class*="share"]',
+      '[class*="breadcrumb"]'
     ];
 
     unwantedSelectors.forEach(selector => {
       const elements = body.querySelectorAll(selector);
       elements.forEach(el => el.remove());
     });
+
+    // 폼/컨트롤 요소 제거 (일반적 관례상 본문 제외)
+    body.querySelectorAll('form, button, input, select, textarea, label').forEach(el => el.remove());
+
+    // 숨김 요소 제거
+    body.querySelectorAll('[hidden], [style*="display:none"], [style*="visibility:hidden"]').forEach(el => el.remove());
 
     return body;
   }
@@ -281,6 +344,8 @@ export class WebClipper {
       .replace(/<!--[\s\S]*?-->/g, '')
       // 불필요한 속성 제거
       .replace(/\s*(class|id|style|onclick|onload)="[^"]*"/g, '')
+      .replace(/\s*aria-[a-z\-]+="[^"]*"/gi, '')
+      .replace(/\s*data-[a-z\-]+="[^"]*"/gi, '')
       // 빈 요소 제거
       .replace(/<(\w+)[^>]*>\s*<\/\1>/g, '');
   }
@@ -374,8 +439,21 @@ export class WebClipper {
 
     // 불필요한 요소 제거
     this.turndownService.addRule('removeUnwanted', {
-      filter: ['script', 'style', 'noscript', 'iframe', 'embed'],
+      filter: ['script', 'style', 'noscript', 'iframe', 'embed', 'form', 'button', 'input', 'select', 'textarea', 'label'],
       replacement: () => '',
+    });
+
+    // UI 전용 컨테이너 제거 (쿠키/팝업/공유/브레드크럼 등)
+    this.turndownService.addRule('removeUiOnly', {
+      filter: (node: any) => {
+        if (!node || (node as any).nodeType !== 1) return false;
+        const el = node as HTMLElement;
+        const cls = `${el.className || ''}`.toLowerCase();
+        const id = `${el.id || ''}`.toLowerCase();
+        const uiHints = ['cookie', 'consent', 'popup', 'modal', 'tooltip', 'popover', 'share', 'breadcrumb', 'gnb', 'lnb'];
+        return uiHints.some(k => cls.includes(k) || id.includes(k));
+      },
+      replacement: () => ''
     });
 
     // 코드 블록 개선

--- a/src/webviewer/ScrapView.module.css
+++ b/src/webviewer/ScrapView.module.css
@@ -59,7 +59,7 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
   white-space: nowrap;
   flex: 0 0 auto;
 }
@@ -72,10 +72,24 @@
   background: var(--accent);
   color: var(--accent-contrast);
   border-color: transparent;
+  text-decoration: none;
 }
 
 .btnPrimary:hover {
-  filter: brightness(0.95);
+  background: #1a1a1a;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+}
+
+.btnPrimary:active {
+  background: #0b0b0b;
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.btnPrimary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.15);
 }
 
 .content {

--- a/src/webviewer/ScrapView.module.css
+++ b/src/webviewer/ScrapView.module.css
@@ -1,0 +1,155 @@
+.viewer {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.card {
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--surface-elev);
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  color: var(--text-primary);
+  font-size: 22px;
+  line-height: 1.35;
+  font-weight: 700;
+}
+
+.meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+  display: flex;
+  gap: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-primary);
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn:hover {
+  background: var(--hover);
+}
+
+.btnPrimary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+
+.btnPrimary:hover {
+  filter: brightness(0.95);
+}
+
+.content {
+  padding: 24px;
+  color: var(--text-primary);
+  background: var(--surface);
+}
+
+/* Theme tokens */
+.themeLight {
+  --surface: #ffffff;
+  --surface-elev: #fafafa;
+  --bg: #f5f5f7;
+  --text-primary: #111111;
+  --text-secondary: #6b7280;
+  --border-color: #e5e7eb;
+  --hover: #f3f4f6;
+  --accent: #111111;
+  --accent-contrast: #ffffff;
+}
+
+.themeDark {
+  --surface: #111213;
+  --surface-elev: #121416;
+  --bg: #0b0c0e;
+  --text-primary: #e5e7eb;
+  --text-secondary: #9ca3af;
+  --border-color: #262a31;
+  --hover: #1a1d21;
+  --accent: #e5e7eb;
+  --accent-contrast: #111213;
+}
+
+.pageBg {
+  background: var(--bg);
+  min-height: 100vh;
+  padding: 28px 16px;
+}
+
+.link {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-secondary);
+}
+
+.pillIcon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+}
+
+.pillLink {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.pillLink:hover {
+  text-decoration: underline;
+}
+
+.pillDivider {
+  color: var(--text-secondary);
+  margin: 0 6px;
+}
+
+

--- a/src/webviewer/ScrapView.module.css
+++ b/src/webviewer/ScrapView.module.css
@@ -25,6 +25,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .title {
@@ -44,6 +46,7 @@
 .actions {
   display: flex;
   gap: 8px;
+  flex: 0 0 auto;
 }
 
 .btn {
@@ -57,6 +60,8 @@
   font-weight: 600;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 .btn:hover {

--- a/src/webviewer/ScrapView.tsx
+++ b/src/webviewer/ScrapView.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { scrapService } from '../services/scrapService';
 import MarkdownRenderer from '../utils/markdownRenderer';
+import styles from './ScrapView.module.css';
+import { IoLinkOutline, IoTimeOutline } from 'react-icons/io5';
 
 interface Props { id: number }
 
@@ -15,6 +17,14 @@ const ScrapView: React.FC<Props> = ({ id }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [scrap, setScrap] = useState<ScrapData | null>(null);
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    try {
+      const saved = localStorage.getItem('scrapViewTheme');
+      return (saved === 'dark' || saved === 'light') ? (saved as 'light' | 'dark') : 'light';
+    } catch {
+      return 'light';
+    }
+  });
 
   useEffect(() => {
     const load = async () => {
@@ -32,22 +42,63 @@ const ScrapView: React.FC<Props> = ({ id }) => {
     load();
   }, [id]);
 
+  useEffect(() => {
+    try {
+      localStorage.setItem('scrapViewTheme', theme);
+    } catch {}
+  }, [theme]);
+
+  const themeClass = useMemo(() => theme === 'dark' ? styles.themeDark : styles.themeLight, [theme]);
+
+  const domain = useMemo(() => {
+    try {
+      if (!scrap?.url) return '';
+      const hostname = new URL(scrap.url).hostname.replace(/^www\./, '');
+      const parts = hostname.split('.');
+      return parts.length >= 3 ? parts.slice(-2).join('.') : hostname;
+    } catch {
+      return '';
+    }
+  }, [scrap?.url]);
+
   if (loading) return <div style={{ padding: 16 }}>불러오는 중...</div>;
   if (error) return <div style={{ padding: 16, color: 'red' }}>{error}</div>;
   if (!scrap) return <div style={{ padding: 16 }}>데이터가 없습니다.</div>;
 
   return (
-    <div style={{ maxWidth: 860, margin: '0 auto', padding: 24 }}>
-      <h1 style={{ fontSize: 24, marginBottom: 8 }}>{scrap.title}</h1>
-      <div style={{ marginBottom: 16, color: '#666' }}>
-        <a href={scrap.url} target="_blank" rel="noreferrer">원문 링크</a>
-        {scrap.createdAt && (
-          <span style={{ marginLeft: 12 }}>
-            {new Date(scrap.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
-          </span>
-        )}
+    <div className={`${styles.pageBg} ${themeClass}`}>
+      <div className={styles.viewer}>
+        <div className={styles.card}>
+          <div className={styles.header}>
+            <div className={styles.titleBlock}>
+              <div className={styles.title}>{scrap.title}</div>
+              <div className={styles.meta}>
+                <span className={styles.pill}>
+                  <span className={styles.pillIcon}><IoLinkOutline size={14} /></span>
+                  <a className={styles.pillLink} href={scrap.url} target="_blank" rel="noreferrer">{domain || '원문 링크'}</a>
+                </span>
+                {scrap.createdAt && (
+                  <span className={styles.pill}>
+                    <span className={styles.pillIcon}><IoTimeOutline size={14} /></span>
+                    {new Date(scrap.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className={styles.actions}>
+              <button className={styles.btn} onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+                {theme === 'light' ? 'Dark' : 'Light'} Mode
+              </button>
+              <a className={`${styles.btn} ${styles.btnPrimary}`} href={scrap.url} target="_blank" rel="noreferrer">
+                원문 보기
+              </a>
+            </div>
+          </div>
+          <div className={styles.content}>
+            <MarkdownRenderer content={scrap.content} />
+          </div>
+        </div>
       </div>
-      <MarkdownRenderer content={scrap.content} />
     </div>
   );
 };

--- a/src/webviewer/ScrapView.tsx
+++ b/src/webviewer/ScrapView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { scrapService } from '../services/scrapService';
 import MarkdownRenderer from '../utils/markdownRenderer';
 import styles from './ScrapView.module.css';
@@ -17,14 +17,6 @@ const ScrapView: React.FC<Props> = ({ id }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [scrap, setScrap] = useState<ScrapData | null>(null);
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-    try {
-      const saved = localStorage.getItem('scrapViewTheme');
-      return (saved === 'dark' || saved === 'light') ? (saved as 'light' | 'dark') : 'light';
-    } catch {
-      return 'light';
-    }
-  });
 
   useEffect(() => {
     const load = async () => {
@@ -42,15 +34,7 @@ const ScrapView: React.FC<Props> = ({ id }) => {
     load();
   }, [id]);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem('scrapViewTheme', theme);
-    } catch {}
-  }, [theme]);
-
-  const themeClass = useMemo(() => theme === 'dark' ? styles.themeDark : styles.themeLight, [theme]);
-
-  const domain = useMemo(() => {
+  const domain = (() => {
     try {
       if (!scrap?.url) return '';
       const hostname = new URL(scrap.url).hostname.replace(/^www\./, '');
@@ -59,14 +43,14 @@ const ScrapView: React.FC<Props> = ({ id }) => {
     } catch {
       return '';
     }
-  }, [scrap?.url]);
+  })();
 
   if (loading) return <div style={{ padding: 16 }}>불러오는 중...</div>;
   if (error) return <div style={{ padding: 16, color: 'red' }}>{error}</div>;
   if (!scrap) return <div style={{ padding: 16 }}>데이터가 없습니다.</div>;
 
   return (
-    <div className={`${styles.pageBg} ${themeClass}`}>
+    <div className={`${styles.pageBg} ${styles.themeLight}`}>
       <div className={styles.viewer}>
         <div className={styles.card}>
           <div className={styles.header}>
@@ -86,9 +70,6 @@ const ScrapView: React.FC<Props> = ({ id }) => {
               </div>
             </div>
             <div className={styles.actions}>
-              <button className={styles.btn} onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
-                {theme === 'light' ? 'Dark' : 'Light'} Mode
-              </button>
               <a className={`${styles.btn} ${styles.btnPrimary}`} href={scrap.url} target="_blank" rel="noreferrer">
                 원문 보기
               </a>

--- a/src/webviewer/UploadView.tsx
+++ b/src/webviewer/UploadView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { globalApiClient } from '../services/globalApiClient';
 import MarkdownRenderer from '../utils/markdownRenderer';
 import styles from './ScrapView.module.css';
@@ -24,14 +24,7 @@ const UploadView: React.FC<Props> = ({ id }) => {
   const [error, setError] = useState<string | null>(null);
   const [upload, setUpload] = useState<UploadData | null>(null);
   const [analysis, setAnalysis] = useState<AnalysisData | null>(null);
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-    try {
-      const saved = localStorage.getItem('scrapViewTheme');
-      return (saved === 'dark' || saved === 'light') ? (saved as 'light' | 'dark') : 'light';
-    } catch {
-      return 'light';
-    }
-  });
+  
 
   useEffect(() => {
     const load = async () => {
@@ -69,13 +62,7 @@ const UploadView: React.FC<Props> = ({ id }) => {
     load();
   }, [id]);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem('scrapViewTheme', theme);
-    } catch {}
-  }, [theme]);
-
-  const themeClass = useMemo(() => theme === 'dark' ? styles.themeDark : styles.themeLight, [theme]);
+  
 
   const domain = useMemo(() => {
     try {
@@ -110,7 +97,7 @@ const UploadView: React.FC<Props> = ({ id }) => {
   if (!upload) return <div style={{ padding: 16 }}>데이터가 없습니다.</div>;
 
   return (
-    <div className={`${styles.pageBg} ${themeClass}`}>
+    <div className={`${styles.pageBg} ${styles.themeLight}`}>
       <div className={styles.viewer}>
         <div className={styles.card}>
           <div className={styles.header}>
@@ -130,9 +117,6 @@ const UploadView: React.FC<Props> = ({ id }) => {
               </div>
             </div>
             <div className={styles.actions}>
-              <button className={styles.btn} onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
-                {theme === 'light' ? 'Dark' : 'Light'} Mode
-              </button>
               <a className={`${styles.btn} ${styles.btnPrimary}`} href={upload.url} target="_blank" rel="noreferrer">
                 원본 파일 열기
               </a>

--- a/src/webviewer/UploadView.tsx
+++ b/src/webviewer/UploadView.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { globalApiClient } from '../services/globalApiClient';
 import MarkdownRenderer from '../utils/markdownRenderer';
+import styles from './ScrapView.module.css';
+import { IoLinkOutline, IoTimeOutline } from 'react-icons/io5';
 
 interface Props { id: number }
 
@@ -22,6 +24,14 @@ const UploadView: React.FC<Props> = ({ id }) => {
   const [error, setError] = useState<string | null>(null);
   const [upload, setUpload] = useState<UploadData | null>(null);
   const [analysis, setAnalysis] = useState<AnalysisData | null>(null);
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    try {
+      const saved = localStorage.getItem('scrapViewTheme');
+      return (saved === 'dark' || saved === 'light') ? (saved as 'light' | 'dark') : 'light';
+    } catch {
+      return 'light';
+    }
+  });
 
   useEffect(() => {
     const load = async () => {
@@ -59,6 +69,29 @@ const UploadView: React.FC<Props> = ({ id }) => {
     load();
   }, [id]);
 
+  useEffect(() => {
+    try {
+      localStorage.setItem('scrapViewTheme', theme);
+    } catch {}
+  }, [theme]);
+
+  const themeClass = useMemo(() => theme === 'dark' ? styles.themeDark : styles.themeLight, [theme]);
+
+  const domain = useMemo(() => {
+    try {
+      if (!upload?.url) return '';
+      const url = upload.url;
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        const hostname = new URL(url).hostname.replace(/^www\./, '');
+        const parts = hostname.split('.');
+        return parts.length >= 3 ? parts.slice(-2).join('.') : hostname;
+      }
+      return '파일';
+    } catch {
+      return '';
+    }
+  }, [upload?.url]);
+
   const refreshAnalysis = useCallback(async () => {
     try {
       const res: any = await globalApiClient.get(`/v1/uploaded-files/${id}/analysis`);
@@ -77,28 +110,52 @@ const UploadView: React.FC<Props> = ({ id }) => {
   if (!upload) return <div style={{ padding: 16 }}>데이터가 없습니다.</div>;
 
   return (
-    <div style={{ maxWidth: 1000, margin: '0 auto', padding: 24 }}>
-      <h1 style={{ fontSize: 24, marginBottom: 8 }}>{upload.title}</h1>
-      <div style={{ marginBottom: 16, color: '#666', display: 'flex', alignItems: 'center' }}>
-        <a href={upload.url} target="_blank" rel="noreferrer">원본 파일 열기</a>
-        {upload.createdAt && (
-          <span style={{ marginLeft: 12 }}>
-            {new Date(upload.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
-          </span>
-        )}
-        <button onClick={refreshAnalysis} style={{ marginLeft: 'auto', padding: '6px 10px', borderRadius: 6, border: '1px solid #e5e7eb', background: '#fff', cursor: 'pointer' }}>새로고침</button>
-      </div>
-      {upload.description && (
-        <div style={{ marginBottom: 16, color: '#333' }}>{upload.description}</div>
-      )}
+    <div className={`${styles.pageBg} ${themeClass}`}>
+      <div className={styles.viewer}>
+        <div className={styles.card}>
+          <div className={styles.header}>
+            <div className={styles.titleBlock}>
+              <div className={styles.title}>{upload.title}</div>
+              <div className={styles.meta}>
+                <span className={styles.pill}>
+                  <span className={styles.pillIcon}><IoLinkOutline size={14} /></span>
+                  <a className={styles.pillLink} href={upload.url} target="_blank" rel="noreferrer">{domain || '원본 파일'}</a>
+                </span>
+                {upload.createdAt && (
+                  <span className={styles.pill}>
+                    <span className={styles.pillIcon}><IoTimeOutline size={14} /></span>
+                    {new Date(upload.createdAt).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className={styles.actions}>
+              <button className={styles.btn} onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+                {theme === 'light' ? 'Dark' : 'Light'} Mode
+              </button>
+              <a className={`${styles.btn} ${styles.btnPrimary}`} href={upload.url} target="_blank" rel="noreferrer">
+                원본 파일 열기
+              </a>
+              <button className={styles.btn} onClick={refreshAnalysis}>
+                새로고침
+              </button>
+            </div>
+          </div>
+          <div className={styles.content}>
+            {upload.description && (
+              <div style={{ marginBottom: 16, color: 'var(--text-primary)' }}>{upload.description}</div>
+            )}
 
-      {analysis ? (
-        <MarkdownRenderer content={analysis.markdown} />
-      ) : (
-        <div style={{ padding: 12, background: '#f8fafc', border: '1px solid #e5e7eb', borderRadius: 6, color: '#333' }}>
-          아직 분석 결과가 없습니다. 처리 완료 후 이곳에 요약/분석 마크다운이 표시됩니다.
+            {analysis ? (
+              <MarkdownRenderer content={analysis.markdown} />
+            ) : (
+              <div style={{ padding: 12, background: 'var(--surface-elev)', border: '1px solid var(--border-color)', borderRadius: 6, color: 'var(--text-secondary)' }}>
+                아직 분석 결과가 없습니다. 처리 완료 후 이곳에 요약/분석 마크다운이 표시됩니다.
+              </div>
+            )}
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-306](https://linear.app/chill-mato/issue/CHI-306/)

## 변경 요약
웹 스크랩 뷰어(ScrapView) UI를 현대적인 카드형 레이아웃으로 개편하고, PDF 뷰어(UploadView)에도 동일한 헤더/메타/액션 패턴을 적용했습니다. 스크랩 리스트 미리보기는 API 원문 `content`를 그대로 사용해 링크/이미지 마크다운이 파싱되지 않도록 했습니다. 또한 스크랩 시 메타데이터를 수집하지 않도록 조정하고, 다크 모드 기능을 제거했습니다.

## 주요 변경사항
- [x] ScrapView UI 전면 개편 (카드 레이아웃, 헤더 메타 pill, 액션 버튼)
- [x] UploadView에 동일 UI 패턴 적용 (도메인/시간 pill, 원본 열기/새로고침)
- [x] 스크랩 리스트 미리보기: 변환 없이 원문 `content` 그대로 표시 (링크 파싱 제거)
- [x] 스크랩 시 메타데이터 미수집 (`includeMetadata=false`)
- [x] 다크 모드 기능 제거 및 라이트 테마 고정
- [x] "원문 보기" 버튼 hover/active/focus 상호작용 개선 (밝기 과도 문제 완화)

## 테스트
- [x] 빌드 확인 (TS/ESLint 무오류)
- [x] 스크랩 생성/조회 정상 동작 (메타데이터 없이 본문만 저장)
- [x] ScrapView
  - [x] 긴 제목/2줄 이상에서도 버튼 폭 유지
  - [x] 도메인/시간 메타 pill 노출
  - [x] 원문 보기 버튼 hover/active/focus 시 명확한 피드백
- [x] UploadView
  - [x] 동일 헤더/버튼 UI 적용
  - [x] 분석 마크다운 존재 시 렌더, 없으면 안내 문구
- [x] 스크랩 리스트 미리보기에서 링크/이미지 마크다운이 앵커/이미지로 변환되지 않음

## 스크린샷/데모 (선택)
<!-- 필요 시 첨부: Before/After, 동작 영상 등 -->

## 기타 참고사항
- 변경된 주요 파일
  - `src/webviewer/ScrapView.tsx` / `src/webviewer/ScrapView.module.css`
  - `src/webviewer/UploadView.tsx`
  - `src/sidepanel/pages/ScrapPage.tsx` (미리보기 원문 사용)
  - `entrypoints/background.ts`, `src/background/index.ts` (클리핑 시 `includeMetadata=false`)
- 접근성: 링크/버튼의 focus-visible 스타일 추가(시인성 향상)
- Breaking changes: 없음