### PR TITLE
[CHI-327] Threads 인페이지 스크랩 기능 추가

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -42,6 +42,18 @@ browser.runtime.onMessage.addListener((request: any, sender: Browser.runtime.Mes
     return true;
   }
 
+  if (request.action === 'proxyImage') {
+    handleProxyImage(request.url)
+      .then((dataUrl) => {
+        sendResponse({ success: true, dataUrl });
+      })
+      .catch((error) => {
+        console.error('❌ Background proxyImage error:', error);
+        sendResponse({ success: false, error: error?.message || String(error) });
+      });
+    return true;
+  }
+
   if (request.action === 'clipAndScrapCurrentPage') {
     handleClipAndScrapCurrentPage(sender)
       .then(response => {
@@ -432,3 +444,34 @@ browser.runtime.onInstalled.addListener(async () => {
 browser.runtime.setUninstallURL('https://tally.so/r/nGZK7z');
 
 export {}; 
+
+/**
+ * 이미지 프록시: 외부 Origin에서 CORP/Referer 정책으로 차단되는 이미지를
+ * background fetch로 불러 data URL로 반환
+ */
+async function handleProxyImage(url: string): Promise<string> {
+  if (!url) throw new Error('Empty URL');
+  try {
+    const resp = await fetch(url, {
+      method: 'GET',
+      // 이미지 호스팅의 Referrer 정책을 우회
+      referrerPolicy: 'no-referrer',
+      // 모드/크리덴셜은 기본값 유지 (이미지 대부분 공개)
+    } as RequestInit);
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}`);
+    }
+    const blob = await resp.blob();
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+    return dataUrl;
+  } catch (e) {
+    // 최후 폴백: wsrv.nl 프록시 시도
+    const wsrv = `https://wsrv.nl/?url=${encodeURIComponent(url)}`;
+    return wsrv;
+  }
+}

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -5,9 +5,15 @@ import FloatingButton from '../components/content/FloatingButton/FloatingButton'
 import { WebClipper } from '../utils/webClipper';
 import { initLinkedInInjector } from '../utils/linkedinInjector';
 import { clipAndScrapCurrentPage } from '../utils/scrapHelper';
+import { initThreadsInjector } from '../utils/threadsInjector';
 
 const App: React.FC = () => {
   const { isReady, currentSelection } = useContentScript();
+  const isThreads = (typeof window !== 'undefined') && (
+    window.location.hostname.includes('threads.net') ||
+    window.location.hostname.includes('threads.com') ||
+    window.location.href.startsWith('https://www.instagram.com/threads/')
+  );
 
   // Background Script로부터의 메시지 처리
   useEffect(() => {
@@ -92,9 +98,23 @@ const App: React.FC = () => {
     };
   }, []);
 
+  // Threads 피드 카드에 Tyquill 버튼 주입
+  useEffect(() => {
+    if (!isThreads) return;
+    let cleanup: (() => void) | undefined;
+    try {
+      console.log('[Tyquill][App] initThreadsInjector() start');
+      cleanup = initThreadsInjector();
+      console.log('[Tyquill][App] initThreadsInjector() done');
+    } catch {}
+    return () => {
+      try { cleanup && cleanup(); } catch {}
+    };
+  }, [isThreads]);
+
   return (
     <div id="tyquill-content-root">
-      <FloatingButton />
+      {!isThreads && <FloatingButton />}
       
       {/* 향후 확장을 위한 추가 컴포넌트들을 위한 컨테이너 */}
       <div id="tyquill-content-components" style={{ display: 'none' }}>

--- a/src/utils/markdownRenderer.tsx
+++ b/src/utils/markdownRenderer.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { browser } from 'wxt/browser';
 
 interface MarkdownRendererProps {
   content: string;
@@ -6,13 +7,14 @@ interface MarkdownRendererProps {
 }
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className }) => {
-  if (!content) return <div className={className}></div>;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  if (!content) return <div className={className} ref={containerRef}></div>;
 
   // 볼드/이탤릭/취소선 텍스트 처리 헬퍼 함수 (개선된 패턴)
   const processTextFormatting = (text: string) => {
     return text
       // 이미지 처리: ![alt](url "optional title") → <img>
-      .replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, '<img src="$2" alt="$1" style="max-width: 100%; height: auto; display: inline-block;" />')
+      .replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, '<img src="$2" alt="$1" referrerpolicy="no-referrer" loading="lazy" style="max-width: 100%; height: auto; display: inline-block;" />')
       // 볼드 처리: **text** (한글과 특수문자 포함하여 더 넓게 매칭)
       .replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>')
       // 이탤릭 처리: *text* (볼드와 겹치지 않도록 개선)
@@ -33,7 +35,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className 
       // 멀티라인 이미지: ![alt...\n\n...](url)
       .replace(/!\[([\s\S]*?)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g, (_m, alt: string, url: string) => {
         const collapsedAlt = (alt as string).replace(/\s+/g, ' ').trim();
-        return `<img src="${url}" alt="${collapsedAlt}" style="max-width: 100%; height: auto; display: inline-block;" />`;
+        return `<img src="${url}" alt="${collapsedAlt}" referrerpolicy="no-referrer" loading="lazy" style="max-width: 100%; height: auto; display: inline-block;" />`;
       })
       // 멀티라인 링크: [text...\n\n...](url) - 이미지가 아닌 경우만 (! 로 시작하지 않는 경우)
       .replace(/(?<!\!)\[([^\[\]]*(?:\n[^\[\]]*)*?)\]\(\s*([^\)]+?)\s*\)/g, (_m, text: string, url: string) => {
@@ -182,8 +184,57 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className 
     return elements;
   };
 
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    const imgs = Array.from(root.querySelectorAll('img')) as HTMLImageElement[];
+    imgs.forEach((img) => {
+      try { img.setAttribute('referrerpolicy', 'no-referrer'); } catch {}
+      try { img.setAttribute('loading', 'lazy'); } catch {}
+
+      const originalSrc = img.getAttribute('data-tyquill-original-src') || img.getAttribute('src') || '';
+      if (!img.getAttribute('data-tyquill-original-src') && originalSrc) {
+        img.setAttribute('data-tyquill-original-src', originalSrc);
+      }
+
+      const onError = async () => {
+        if ((img as any)._tyquillImgBusy) return;
+        (img as any)._tyquillImgBusy = true;
+        try {
+          const triedProxy = img.getAttribute('data-tyquill-proxy-tried') === '1';
+          const triedWsrv = img.getAttribute('data-tyquill-wsrv-tried') === '1';
+          const src0 = img.getAttribute('data-tyquill-original-src') || img.src || '';
+          if (!src0) return;
+
+          if (!triedWsrv) {
+            img.setAttribute('data-tyquill-wsrv-tried', '1');
+            const wsrv = `https://wsrv.nl/?url=${encodeURIComponent(src0)}`;
+            img.src = wsrv;
+            (img as any)._tyquillImgBusy = false;
+            return;
+          }
+
+          if (!triedProxy) {
+            img.setAttribute('data-tyquill-proxy-tried', '1');
+            try {
+              const resp = await browser.runtime.sendMessage({ action: 'proxyImage', url: src0 });
+              if (resp?.success && resp?.dataUrl) {
+                img.src = resp.dataUrl;
+              }
+            } catch {}
+          }
+        } finally {
+          (img as any)._tyquillImgBusy = false;
+        }
+      };
+
+      img.removeEventListener('error', onError as any);
+      img.addEventListener('error', onError as any, { once: false });
+    });
+  });
+
   return (
-    <div className={className}>
+    <div className={className} ref={containerRef}>
       {renderMarkdown(content)}
     </div>
   );

--- a/src/utils/threadsInjector.ts
+++ b/src/utils/threadsInjector.ts
@@ -1,0 +1,428 @@
+import { browser } from 'wxt/browser';
+
+type CleanupFn = () => void;
+
+function isThreadsSite(): boolean {
+  const host = location.hostname;
+  const href = location.href;
+  return host.includes('threads.net') || host.includes('threads.com') || href.startsWith('https://www.instagram.com/threads/');
+}
+
+function isDarkMode(): boolean {
+  try {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  } catch {
+    return false;
+  }
+}
+
+function ensureStylesInjected(): void {
+  if (document.getElementById('tyquill-threads-action-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'tyquill-threads-action-styles';
+  style.textContent = `
+    [data-tyquill="threads-action"]{
+      display:inline-flex;align-items:center;justify-content:center;
+      width:var(--x1kdnp2l,36px);height:var(--x1kdnp2l,36px);
+      border:none;border-radius:50%;padding:0;margin-right:var(--x1m69m10,8px);
+      background:transparent;
+      cursor:pointer;
+      transform:translate(var(--tyquill-button-translate-x,-8px), var(--tyquill-button-translate-y,-8px));
+      transition:background-color 150ms ease
+    }
+    [data-tyquill="threads-action"] img, [data-tyquill="threads-action"] svg{width:16px;height:16px;display:block;object-fit:contain;transform:translate(var(--tyquill-icon-translate-x,0px), var(--tyquill-icon-translate-y,0px))}
+    [data-tyquill="threads-action"]:hover{background:var(--hover-overlay, rgba(0,0,0,.06))}
+    [data-tyquill="threads-action"]:focus-visible{outline:none;box-shadow:0 0 0 2px rgba(0,150,136,.35)}
+
+    /* Color scheme adjustments: dark → white, light → gray */
+    @media (prefers-color-scheme: dark) {
+      [data-tyquill="threads-action"] img, [data-tyquill="threads-action"] svg { filter: none; opacity: 1; }
+    }
+    @media (prefers-color-scheme: light) {
+      /* Convert white source to mid-gray ~ #808080 */
+      [data-tyquill="threads-action"] img, [data-tyquill="threads-action"] svg { filter: invert(0.5); opacity: 1; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function createInlineTyquillSVG(): SVGElement {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', 'Tyquill');
+  // 크기는 CSS에서 통일 관리
+  svg.style.filter = isDarkMode() ? '' : 'invert(1)';
+  const g = document.createElementNS(svgNS, 'g');
+  g.setAttribute('fill', '#FFFFFF');
+  // 간단한 깃펜 + 점 형태 (브랜딩 대체, CSP 우회용)
+  const path1 = document.createElementNS(svgNS, 'path');
+  path1.setAttribute('d', 'M3 21l3-8 8-3-3 8-8 3z');
+  const path2 = document.createElementNS(svgNS, 'path');
+  path2.setAttribute('d', 'M14 3l7 7-2 2-7-7 2-2z');
+  const circle = document.createElementNS(svgNS, 'circle');
+  circle.setAttribute('cx', '19');
+  circle.setAttribute('cy', '5');
+  circle.setAttribute('r', '2');
+  g.appendChild(path1);
+  g.appendChild(path2);
+  g.appendChild(circle);
+  svg.appendChild(g);
+  return svg;
+}
+
+function createTyquillIconElement(): HTMLElement | SVGElement {
+  const img = document.createElement('img');
+  img.src = 'https://4bvbvpozg7fnspb5.public.blob.vercel-storage.com/white-logo.svg';
+  img.alt = 'Tyquill';
+  img.style.display = 'block';
+  img.style.objectFit = 'contain';
+  img.onerror = () => {
+    try {
+      const svg = createInlineTyquillSVG();
+      img.replaceWith(svg);
+    } catch {}
+  };
+  return img;
+}
+
+function createTyquillButton(): HTMLDivElement {
+  const button = document.createElement('div');
+  button.setAttribute('role', 'button');
+  button.setAttribute('tabindex', '0');
+  button.setAttribute('aria-label', 'Save with Tyquill');
+  button.setAttribute('data-tyquill', 'threads-action');
+  // 위치 보정은 CSS 변수로 제어 (기본 -8px), 상황에 따라 adjustButtonOffset에서 0px로 변경
+
+  const icon = createTyquillIconElement();
+  try {
+    (icon as HTMLElement).style.width = '16px';
+    (icon as HTMLElement).style.height = '16px';
+    (icon as HTMLElement).style.removeProperty('transform');
+  } catch {}
+  button.appendChild(icon);
+
+  button.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      await doScrapFromThreadsButton(button);
+    } catch {}
+  }, true);
+
+  return button;
+}
+
+// 사용자 제시 셀렉터에 부합하는 버튼 목록 컨테이너에 직접 주입 (클래스 의존 우선순위는 낮음)
+function injectIntoExplicitButtonLists(root: ParentNode = document): void {
+  const selector = 'div.x6s0dn4.xamitd3.x40hh3e.x78zum5.x1q0g3np.x1xdureb.x1fc57z9.x1hm9lzh.xvijh9v';
+  const containers = (root as Document | Element).querySelectorAll?.(selector);
+  containers?.forEach((el) => {
+    if (!(el instanceof Element)) return;
+    if (el.querySelector('[data-tyquill="threads-action"], [data-tyquill="threads-action-wrapper"]')) return;
+
+    // 기준 앵커(첫 번째 버튼 래퍼)를 복제해 구조/간격을 보존
+    const anchor = el.querySelector(':scope > div');
+    if (anchor) {
+      try {
+        const anchorInner = anchor.querySelector(':scope > div');
+        const anchorContent = anchorInner?.querySelector(':scope > div');
+
+        const wrapper = anchor.cloneNode(false) as HTMLElement; // 같은 클래스 유지, 자식 없음
+        wrapper.setAttribute('data-tyquill', 'threads-action-wrapper');
+
+        const roleBtn = document.createElement('div');
+        roleBtn.className = (anchorInner as HTMLElement | null)?.className || '';
+        roleBtn.setAttribute('role', 'button');
+        roleBtn.setAttribute('tabindex', '0');
+        roleBtn.setAttribute('aria-label', 'Save with Tyquill');
+        roleBtn.setAttribute('data-tyquill', 'threads-action');
+
+        const content = document.createElement('div');
+        content.className = (anchorContent as HTMLElement | null)?.className || '';
+
+        const iconEl = createTyquillIconElement();
+        try {
+          (iconEl as HTMLElement).style.width = '16px';
+          (iconEl as HTMLElement).style.height = '16px';
+          (iconEl as HTMLElement).style.removeProperty('transform');
+        } catch {}
+        content.appendChild(iconEl);
+        roleBtn.appendChild(content);
+        roleBtn.addEventListener('click', async (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          try { await doScrapFromThreadsButton(roleBtn); } catch {}
+        }, true);
+
+        wrapper.appendChild(roleBtn);
+        try {
+          el.insertBefore(wrapper, el.firstElementChild);
+        } catch {
+          el.appendChild(wrapper);
+        }
+        try { adjustButtonOffset(roleBtn as HTMLElement); } catch {}
+        return;
+      } catch {}
+    }
+
+    // 폴백: 단순 버튼을 직접 추가
+    try {
+      const b = createTyquillButton();
+      el.insertBefore(b, el.firstElementChild);
+      try { adjustButtonOffset(b as HTMLElement); } catch {}
+    } catch {
+      const b = createTyquillButton();
+      el.appendChild(b);
+      try { adjustButtonOffset(b as HTMLElement); } catch {}
+    }
+  });
+}
+
+export function initThreadsInjector(): CleanupFn {
+  if (!isThreadsSite()) { return () => {}; }
+
+  ensureStylesInjected();
+  // 초기 스캔: 명시 셀렉터 기반 버튼 목록 컨테이너에만 주입
+  injectIntoExplicitButtonLists(document);
+
+  // 초기 로딩 타이밍 보정 폴링은 제거 (단순화)
+
+  // 동적 로딩 대응: 새로 추가되는 노드에서만 인라인 컨트롤 스캔
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (m.type === 'childList') {
+        const added = Array.from(m.addedNodes).filter((n) => n instanceof Element) as Element[];
+        added.forEach((node) => {
+          if (!(node instanceof Element)) return;
+          injectIntoExplicitButtonLists(node);
+        });
+      }
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  return () => {
+    observer.disconnect();
+  };
+}
+
+
+function adjustButtonOffset(btn: HTMLElement): void {
+  try {
+    const wrapper = btn.parentElement as HTMLElement | null; // data-tyquill="threads-action-wrapper"
+    const container = wrapper?.parentElement as HTMLElement | null;
+    if (!wrapper || !container) return;
+
+    // 기본: 첫 자식이면 -8px 유지
+    const isFirst = container.firstElementChild === wrapper;
+    if (!isFirst) {
+      // 끼는 케이스: X=+8px, Y=0px
+      btn.style.setProperty('--tyquill-button-translate-x', '8px');
+      btn.style.setProperty('--tyquill-button-translate-y', '0px');
+      return;
+    }
+
+    // 특수 케이스: 바로 오른쪽에 매우 작은 아이콘(예: 15px 프로필)이 붙어 있으면 겹침 방지 위해 0px
+    const next = wrapper.nextElementSibling as HTMLElement | null;
+    if (next) {
+      const tinyImg = next.querySelector('img') as HTMLImageElement | null;
+      const widthAttr = Number(tinyImg?.getAttribute('width') || 0);
+      const heightAttr = Number(tinyImg?.getAttribute('height') || 0);
+      const rect = tinyImg?.getBoundingClientRect();
+      const w = rect?.width || widthAttr || 0;
+      const h = rect?.height || heightAttr || 0;
+      if ((w > 0 && w <= 18) || (h > 0 && h <= 18)) {
+        // 끼는 케이스: X=+8px, Y=0px
+        btn.style.setProperty('--tyquill-button-translate-x', '8px');
+        btn.style.setProperty('--tyquill-button-translate-y', '0px');
+        return;
+      }
+    }
+  } catch {}
+}
+
+function normalizeText(text: string): string {
+  return (text || '')
+    .replace(/\u00A0/g, ' ')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function toAbsoluteUrl(href: string | null | undefined): string {
+  const h = (href || '').trim();
+  if (!h) return location.href;
+  if (/^https?:\/\//i.test(h)) return h;
+  try { return new URL(h, window.location.origin).toString(); } catch { return h; }
+}
+
+function getPostRootFromButton(el: Element): HTMLElement {
+  let cur: HTMLElement | null = el as HTMLElement;
+  for (let i = 0; i < 8 && cur; i++) {
+    const hasPermalink = cur.querySelector('a[href*="/post/"]');
+    const hasUser = cur.querySelector('a[href^="/@"]');
+    if (hasPermalink && hasUser) return cur;
+    cur = cur.parentElement;
+  }
+  const article = (el.closest('article') as HTMLElement | null) || (el.closest('[role="article"]') as HTMLElement | null);
+  return article || (el.closest('div') as HTMLElement) || document.body;
+}
+
+function findAncestorWithContentArea(el: Element): HTMLElement | null {
+  let cur: HTMLElement | null = el as HTMLElement;
+  while (cur && cur !== document.body) {
+    if (cur.querySelector('div.x1xdureb.xkbb5z.x13vxnyz')) return cur;
+    cur = cur.parentElement;
+  }
+  return null;
+}
+
+function extractAuthorName(root: HTMLElement): string | null {
+  // 1) 사용자 링크에서 텍스트 추출
+  const userLink = root.querySelector('a[href^="/@"]') as HTMLAnchorElement | null;
+  if (userLink) {
+    const span = (userLink.querySelector('span') as HTMLElement | null);
+    const visible = normalizeText(span?.innerText || userLink.innerText || '');
+    if (visible) return visible;
+    // 2) href 경로에서 파싱
+    const href = userLink.getAttribute('href') || '';
+    const m = href.replace(/^\/@@/, '/@').match(/^\/@([^/?#]+)/);
+    if (m && m[1]) return decodeURIComponent(m[1]);
+  }
+  // 3) 프로필 이미지 alt 파싱: "xxx님의 프로필 사진"
+  const img = root.querySelector('img[alt$="님의 프로필 사진"]') as HTMLImageElement | null;
+  if (img?.alt) {
+    const alt = img.alt.replace(/님의 프로필 사진$/, '').trim();
+    if (alt) return alt;
+  }
+  return null;
+}
+
+function extractPermalink(root: HTMLElement): string {
+  const a = root.querySelector('a[href*="/post/"]') as HTMLAnchorElement | null;
+  if (a?.href || a?.getAttribute('href')) {
+    return toAbsoluteUrl(a.href || a.getAttribute('href') || '');
+  }
+  // fallback: 시간 링크 등 다른 앵커
+  const any = root.querySelector('a[href^="/@"]') as HTMLAnchorElement | null;
+  if (any?.href || any?.getAttribute('href')) {
+    return toAbsoluteUrl(any.href || any.getAttribute('href') || '');
+  }
+  return location.href;
+}
+
+function extractImageMarkdown(root: HTMLElement): string[] {
+  const md: string[] = [];
+  // 본문 영역 우선 검색
+  const searchRoot = (root.querySelector('div.x1xdureb.xkbb5z.x13vxnyz') as HTMLElement | null) || root;
+  const imgs = Array.from(searchRoot.querySelectorAll('img')) as HTMLImageElement[];
+  imgs.forEach((img) => {
+    // 제외 규칙: Tyquill 아이콘, 프로필 이미지, 액션바 내부, 아주 작은 아이콘
+    if (img.closest('[data-tyquill]')) return;
+    const alt = (img.getAttribute('alt') || '').trim();
+    if (/님의 프로필 사진$/.test(alt)) return;
+    if (img.closest('.x4vbgl9, .x1qfufaz, .x1k70j0n')) return;
+    const w = Number(img.getAttribute('width') || img.width || 0);
+    const h = Number(img.getAttribute('height') || img.height || 0);
+    if ((w && w < 60) || (h && h < 60)) return;
+
+    const url = toAbsoluteUrl(img.currentSrc || img.src || '');
+    if (!url || /^data:/i.test(url)) return;
+    const safeAlt = alt.replace(/[\r\n]+/g, ' ').trim();
+    md.push(`![${safeAlt}](${url})`);
+  });
+  return md;
+}
+
+function collectPostText(root: HTMLElement, authorHint?: string): string {
+  // 1) 우선 콘텐츠 섹션(본문 영역) 범위 내에서 텍스트 추출 시도
+  const contentArea = root.querySelector('div.x1xdureb.xkbb5z.x13vxnyz') as HTMLElement | null;
+  const textCandidates: string[] = [];
+
+  const pushIfValid = (txt: string) => {
+    const t = normalizeText(txt);
+    if (!t) return;
+    // 작성자명만 단독으로 들어가는 라인은 제외
+    if (authorHint && t === authorHint) return;
+    textCandidates.push(t);
+  };
+
+  if (contentArea) {
+    // 대표 본문 블록 (샘플 기반)
+    const mainText = contentArea.querySelector('div.x1a6qonq') as HTMLElement | null;
+    if (mainText && !mainText.closest('.xezivpi, [role="button"], [aria-haspopup="menu"]')) {
+      pushIfValid(mainText.innerText || '');
+    }
+    // 추가 후보: 콘텐츠 섹션 내 dir="auto" 텍스트 노드들
+    contentArea.querySelectorAll('div[dir="auto"], span[dir="auto"]').forEach((el) => {
+      if ((el as HTMLElement).closest('.xezivpi, [role="button"], [aria-haspopup="menu"]')) return;
+      pushIfValid((el as HTMLElement).innerText || '');
+    });
+  }
+
+  // 2) 콘텐츠 섹션에서 못 찾은 경우: 전체 루트에서 본문 후보를 최대 길이 기준으로 선택
+  if (textCandidates.length === 0) {
+    const blocks = Array.from(root.querySelectorAll('div.x1a6qonq')) as HTMLElement[];
+    const scored = blocks
+      .map((el) => normalizeText(el.innerText || ''))
+      .filter((t) => t && (!authorHint || t !== authorHint))
+      .sort((a, b) => b.length - a.length);
+    if (scored[0]) textCandidates.push(scored[0]);
+  }
+
+  // 3) 최후 폴백: 헤더/버튼/아이콘/프로필/유저링크 제거 후 텍스트 추출
+  if (textCandidates.length === 0) {
+    const clone = root.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll([
+      '[data-tyquill]',
+      'button',
+      '[role="button"]',
+      'svg',
+      'time',
+      'video',
+      'audio',
+      'img',
+      'a[href^="/@"]',
+      'a[role="button"]',
+      '[aria-haspopup="menu"]',
+      // Threads 액션 바 및 소셜 카운트 영역 휴리스틱 제거
+      '.x4vbgl9',
+      '.x1qfufaz',
+      '.x1k70j0n',
+      '.xezivpi',
+    ].join(',')).forEach((n) => n.remove());
+    const txt = normalizeText(clone.innerText || '');
+    if (txt && (!authorHint || txt !== authorHint)) textCandidates.push(txt);
+  }
+
+  // 가장 유의미한 텍스트 선택: 길이 우선, 줄바꿈 정리, 작성자명 라인 제거
+  const joined = normalizeText(textCandidates.join('\n\n'));
+  const lines = joined.split('\n').map((s) => s.trim()).filter(Boolean);
+  const filtered = lines.filter((l) => !authorHint || l !== authorHint);
+  const dedup = Array.from(new Set(filtered));
+  return normalizeText(dedup.join('\n'));
+}
+
+async function doScrapFromThreadsButton(buttonEl: Element): Promise<void> {
+  const root = findAncestorWithContentArea(buttonEl) || getPostRootFromButton(buttonEl);
+  const author = extractAuthorName(root) || '';
+  let content = collectPostText(root, author);
+  const title = author ? `Threads | ${author}` : 'Threads';
+  const url = extractPermalink(root);
+  const images = extractImageMarkdown(root);
+  if (images.length > 0) {
+    content = content ? `${content}\n\n${images.join('\n')}` : images.join('\n');
+  }
+  if (!content.trim()) {
+    // 콘텐츠가 없으면 페이지 스크랩으로 폴백하지 않고 종료
+  }
+  try {
+    await browser.runtime.sendMessage({
+      action: 'scrapExtracted',
+      data: { content, title, url }
+    });
+  } catch {}
+}
+


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-327](https://linear.app/chill-mato/issue/CHI-327/)

## 변경 요약
- Threads 피드에서 Tyquill 버튼 클릭 시, 가장 가까운 게시물 컨테이너 기준으로 본문/작성자/퍼머링크를 정확히 추출하고, 제목은 "Threads | {사용자명}" 형식으로 저장되도록 개선
- 이미지가 외부 CDN(CORP/Referrer 정책)으로 차단될 때 프록시/데이터 URL로 자동 대체하여 사이드패널에서 정상 표시되도록 처리
- 버튼 위치 보정 로직 개선: 일반 케이스는 X -8px, ‘끼는’ 케이스는 X +8px, Y 0px로 보정하여 겹침 방지
- 액션 바(좋아요/답글/리포스트/공유하기) 영역의 텍스트/숫자 본문 혼입 제거

## 주요 변경사항
- `src/utils/threadsInjector.ts`
  - 클릭 시 컨테이너 탐색: 버튼 기준 가장 가까운 본문 섹션(`.x1xdureb.xkbb5z.x13vxnyz`)을 포함하는 조상 우선 사용
  - 본문 수집: 본문 블록(`div.x1a6qonq`, `*[dir="auto"]`)에서 텍스트 추출, 작성자명 중복 라인/액션 바 영역(`.xezivpi`) 제외, 폴백 시 버튼/메뉴/아이콘/이미지/액션 바 영역 제거 후 텍스트 추출
  - 작성자명 추출: 사용자 링크(`/@{id}`), 프로필 이미지 alt("님의 프로필 사진") 등으로 다단계 휴리스틱
  - 퍼머링크 추출: `/post/` 포함 앵커 우선, 폴백 허용
  - 이미지 마크다운 추가: 본문 하단에 `![alt](url)` 추가(프로필/아이콘/작은 이미지 제외)
  - 제목 포맷: `Threads | {작성자명}` (작성자 없으면 `Threads`)
  - 버튼 오프셋: 기본 `X -8px, Y -8px`; ‘끼는’ 케이스(첫 자식 아님 또는 다음 형제에 18px 이하 작은 아이콘)에서는 `X +8px, Y 0px`

- `src/utils/markdownRenderer.tsx`
  - 마크다운 이미지 렌더 시 `<img referrerpolicy="no-referrer" loading="lazy">` 적용
  - onerror 훅 추가: 로드 실패 시 1차 `wsrv.nl` 프록시, 2차 백그라운드 `proxyImage`를 통해 data URL로 대체

- `src/background/index.ts`
  - `proxyImage` 메시지 처리 및 `handleProxyImage(url)` 구현: fetch로 이미지를 받아 data URL 반환(실패 시 `wsrv.nl` 폴백)

- `entrypoints/content.tsx`
  - 권장 구성 유지: `runAt: 'document_idle'`, `allFrames: true`

## 테스트
- [ ] 빌드 확인
- [ ] Threads 피드 카드에서 Tyquill 버튼 클릭 시 스크랩 생성 확인
- [ ] 제목이 "Threads | {사용자명}"으로 저장되는지 확인
- [ ] 본문에 액션 바 텍스트/숫자 미포함 확인
- [ ] 이미지가 차단되는 케이스에서 프록시/data URL로 정상 표시되는지 확인(네트워크 탭으로 200 확인)
- [ ] 일반 카드: 버튼 위치 X -8px/Y -8px, 끼는 카드: X +8px/Y 0px 동작 확인

## 스크린샷/데모 (선택)
<img width="661" height="634" alt="image" src="https://github.com/user-attachments/assets/ef1c1a34-551a-48e2-abf1-6116115b810e" />
<img width="661" height="634" alt="image" src="https://github.com/user-attachments/assets/ed9da5a8-c343-4bee-9b56-890c29b42f76" />
<img width="504" height="877" alt="image" src="https://github.com/user-attachments/assets/2fe86a89-c53b-4b7f-b123-c9d7970be9a9" />
<img width="1920" height="1110" alt="image" src="https://github.com/user-attachments/assets/a5080ab5-cdd6-4c85-9cd7-06ed946b5794" />

## 기타 참고사항
- 이미지 프록시는 onerror 시에만 동작하며, 기본적으로 원본 URL을 우선 시도합니다.
- wsrv.nl → 백그라운드 프록시 순으로 폴백하므로 대부분의 CDN 차단 정책에서도 표시됩니다.
- Threads DOM 클래스 네이밍은 변경 가능성이 있으므로, 주요 셀렉터 변경 시 후속 보정 필요할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds native integration for Threads: injects a “Save with Tyquill” action on posts and handles dynamic content.
  - Detects Threads pages and hides the floating button there for a cleaner UI.
  - Enhances Markdown image handling with lazy loading and referrer-safe requests.

- Bug Fixes
  - Improves image reliability by adding automatic fallbacks when images fail to load due to cross-origin or referrer restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->