### PR TITLE
[CHI-341] Youtube 인페이지 스크랩 기능 추가

### DIFF
--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -6,6 +6,7 @@ import { WebClipper } from '../utils/webClipper';
 import { initLinkedInInjector } from '../utils/linkedinInjector';
 import { clipAndScrapCurrentPage } from '../utils/scrapHelper';
 import { initThreadsInjector } from '../utils/threadsInjector';
+import { initYouTubeInjector } from '../utils/youtubeInjector';
 
 const App: React.FC = () => {
   const { isReady, currentSelection } = useContentScript();
@@ -13,6 +14,10 @@ const App: React.FC = () => {
     window.location.hostname.includes('threads.net') ||
     window.location.hostname.includes('threads.com') ||
     window.location.href.startsWith('https://www.instagram.com/threads/')
+  );
+  const isYouTube = (typeof window !== 'undefined') && (
+    window.location.hostname.includes('youtube.com') ||
+    window.location.hostname.includes('m.youtube.com')
   );
 
   // Background Script로부터의 메시지 처리
@@ -111,6 +116,27 @@ const App: React.FC = () => {
       try { cleanup && cleanup(); } catch {}
     };
   }, [isThreads]);
+
+  // YouTube 동영상 페이지에 Tyquill 버튼 주입 (owner/subscribe 인접)
+  useEffect(() => {
+    if (!isYouTube) return;
+    let cleanup: (() => void) | undefined;
+    try {
+      cleanup = initYouTubeInjector();
+    } catch {}
+
+    const handleClick = async () => {
+      try {
+        await clipAndScrapCurrentPage();
+      } catch (e) {}
+    };
+    window.addEventListener('tyquill:yt-button-click', handleClick as EventListener);
+
+    return () => {
+      try { cleanup && cleanup(); } catch {}
+      window.removeEventListener('tyquill:yt-button-click', handleClick as EventListener);
+    };
+  }, [isYouTube]);
 
   return (
     <div id="tyquill-content-root">

--- a/src/utils/youtubeInjector.ts
+++ b/src/utils/youtubeInjector.ts
@@ -1,0 +1,383 @@
+import { browser } from 'wxt/browser';
+
+type CleanupFn = () => void;
+
+const WHITE_LOGO_URL = 'https://4bvbvpozg7fnspb5.public.blob.vercel-storage.com/white-logo.svg';
+
+function isYouTubeSite(): boolean {
+  try {
+    const host = window.location.hostname;
+    return host.includes('youtube.com') || host.includes('m.youtube.com');
+  } catch {
+    return false;
+  }
+}
+
+function parseRgbColor(rgb: string): { r: number; g: number; b: number } | null {
+  const m = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+  if (!m) return null;
+  return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+function parseHexColor(hex: string): { r: number; g: number; b: number } | null {
+  const h = hex.trim();
+  const m = h.match(/^#([0-9a-fA-F]{6})$/);
+  if (!m) return null;
+  const v = m[1];
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return { r, g, b };
+}
+
+function luminanceFromRGB(rgb: { r: number; g: number; b: number } | null): number | null {
+  if (!rgb) return null;
+  return 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b;
+}
+
+function isYouTubeDarkTheme(): boolean {
+  try {
+    // 1) Prefer CSS variable --yt-spec-base-background if available
+    const csRoot = getComputedStyle(document.documentElement);
+    const baseBg = (csRoot.getPropertyValue('--yt-spec-base-background') || '').trim();
+    let lum: number | null = null;
+    if (baseBg) {
+      lum = luminanceFromRGB(parseRgbColor(baseBg) || parseHexColor(baseBg));
+    }
+
+    // 2) If not conclusive, inspect main containers' backgroundColor
+    if (lum == null) {
+      const candidates = [
+        document.querySelector('ytd-app') as HTMLElement | null,
+        document.querySelector('tp-yt-app') as HTMLElement | null,
+        document.body as HTMLElement | null,
+        document.documentElement as HTMLElement | null,
+      ].filter(Boolean) as HTMLElement[];
+      for (const el of candidates) {
+        const bg = getComputedStyle(el).backgroundColor;
+        const L = luminanceFromRGB(parseRgbColor(bg));
+        if (L != null) { lum = L; break; }
+      }
+    }
+
+    // 3) If still null, check text primary color (dark theme uses very bright text)
+    if (lum == null) {
+      const textPrimary = (csRoot.getPropertyValue('--yt-spec-text-primary') || '').trim();
+      const Ltext = luminanceFromRGB(parseRgbColor(textPrimary) || parseHexColor(textPrimary));
+      if (Ltext != null) {
+        // High-luminance text implies dark theme background
+        return Ltext > 180;
+      }
+    }
+
+    if (lum != null) {
+      // Dark theme if background luminance is low
+      return lum < 80;
+    }
+  } catch {}
+
+  // 4) Fallback to OS setting only if nothing else worked
+  try { return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches); } catch {}
+  return false;
+}
+
+function ensureStylesInjected(): void {
+  if (document.getElementById('tyquill-yt-action-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'tyquill-yt-action-styles';
+  style.textContent = `
+    /* YouTube action button styles */
+    button.tyquill-yt-action-btn[data-tyquill="yt-action"] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      height: 36px;
+      padding: 0 16px;
+      border: none;
+      border-radius: 18px;
+      cursor: pointer;
+      background-color: var(--yt-spec-additive-background, rgba(0,0,0,0.05));
+      color: var(--yt-spec-text-primary, currentColor);
+      transition: background-color 150ms ease;
+      /* prevent width change and text wrapping */
+      white-space: nowrap;
+      flex: 0 0 auto;
+      min-width: max-content;
+      box-sizing: border-box;
+    }
+    button.tyquill-yt-action-btn[data-tyquill="yt-action"]:hover {
+      background-color: var(--yt-spec-button-chip-background-hover, rgba(0,0,0,0.1));
+    }
+    button.tyquill-yt-action-btn[data-tyquill="yt-action"]:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(0,150,136,.35);
+    }
+    button.tyquill-yt-action-btn[data-tyquill="yt-action"] img {
+      width: 16px;
+      height: 16px;
+      display: block;
+      object-fit: contain;
+      flex: 0 0 auto;
+    }
+    button.tyquill-yt-action-btn[data-tyquill="yt-action"] span {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Media queries retained for OS-level themes; inline style will override if site theme differs */
+    @media (prefers-color-scheme: light) {
+      button.tyquill-yt-action-btn[data-tyquill="yt-action"] img { filter: invert(1) !important; }
+    }
+    @media (prefers-color-scheme: dark) {
+      button.tyquill-yt-action-btn[data-tyquill="yt-action"] img { filter: none !important; }
+      button.tyquill-yt-action-btn[data-tyquill="yt-action"] {
+        background-color: var(--yt-spec-static-overlay-button-secondary, rgba(255,255,255,0.1));
+        color: var(--yt-spec-static-overlay-text-primary, #fff);
+      }
+      button.tyquill-yt-action-btn[data-tyquill="yt-action"]:hover {
+        background-color: var(--yt-spec-static-overlay-button-primary, rgba(255,255,255,0.3));
+      }
+    }
+
+    /* Try to keep spacing consistent when near subscribe button */
+    #owner #subscribe-button:has(+ [data-tyquill="yt-action"]) {
+      margin-right: 8px;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function applyIconTheme(target?: ParentNode): void {
+  const isDark = isYouTubeDarkTheme();
+  const filterValue = isDark ? 'none' : 'invert(1)';
+  const scope = (target || document);
+  scope.querySelectorAll?.('button[data-tyquill="yt-action"] img').forEach((n) => {
+    try { (n as HTMLElement).style.setProperty('filter', filterValue, 'important'); } catch {}
+  });
+}
+
+function querySubscribeHost(root: ParentNode = document): { owner: Element, subscribe: Element } | null {
+  // Primary path: #owner contains #subscribe-button
+  const owner = root.querySelector('#owner') as Element | null;
+  if (owner) {
+    const subscribe = owner.querySelector('#subscribe-button') as Element | null;
+    if (subscribe) return { owner, subscribe };
+  }
+
+  // Alternative paths observed in templates
+  const ownerAlt = root.querySelector('ytd-watch-metadata #owner') as Element | null;
+  if (ownerAlt) {
+    const subscribeAlt = ownerAlt.querySelector('#subscribe-button') as Element | null;
+    if (subscribeAlt) return { owner: ownerAlt, subscribe: subscribeAlt };
+  }
+
+  // Shorts/watch variations
+  const ownerAny = root.querySelector('ytd-watch-metadata, ytd-reel-player-header-renderer') as Element | null;
+  if (ownerAny) {
+    const subscribeAny = ownerAny.querySelector('#owner #subscribe-button, #subscribe-button') as Element | null;
+    if (subscribeAny) return { owner: ownerAny, subscribe: subscribeAny };
+  }
+
+  return null;
+}
+
+function getInjectionParent(subscribeEl: Element): Element | null {
+  // Place our button as a sibling of the subscribe button's host container
+  // On YouTube, #subscribe-button is a container; we will insert after it under the same parent
+  const parent = subscribeEl.parentElement;
+  if (parent && parent instanceof HTMLElement) return parent;
+  return null;
+}
+
+function needsInjection(parent: Element): boolean {
+  return !parent.querySelector('[data-tyquill="yt-action"]');
+}
+
+function createTyquillButton(): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.setAttribute('aria-label', 'Save with Tyquill');
+  button.setAttribute('data-tyquill', 'yt-action');
+  button.className = 'tyquill-yt-action-btn';
+
+  const img = document.createElement('img');
+  img.src = WHITE_LOGO_URL;
+  img.alt = 'Tyquill';
+  try {
+    const filterValue = isYouTubeDarkTheme() ? 'none' : 'invert(1)';
+    img.style.setProperty('filter', filterValue, 'important');
+  } catch {}
+
+  const label = document.createElement('span');
+  label.textContent = '스크랩';
+  label.style.fontSize = '14px';
+  label.style.lineHeight = '16px';
+  label.style.whiteSpace = 'nowrap';
+
+  button.appendChild(img);
+  button.appendChild(label);
+
+  return button;
+}
+
+function normalizeText(text: string): string {
+  return (text || '')
+    .replace(/\u00A0/g, ' ')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function extractTitle(): string {
+  const h1 = document.querySelector('ytd-watch-metadata h1 yt-formatted-string') as HTMLElement | null
+    || document.querySelector('h1 > yt-formatted-string') as HTMLElement | null
+    || document.querySelector('h1#title') as HTMLElement | null;
+  return normalizeText(h1?.innerText || document.title.replace(/ - YouTube$/, '') || 'YouTube');
+}
+
+function extractDescription(): string {
+  // Prefer description within watch metadata area
+  const candidates: Element[] = [];
+  const sel = [
+    'ytd-watch-metadata #description',
+    '#description.ytd-watch-metadata',
+    'ytd-video-secondary-info-renderer #description',
+    'yt-formatted-string#description'
+  ];
+  sel.forEach(s => { const el = document.querySelector(s); if (el) candidates.push(el); });
+  const picked = candidates.find(Boolean) as HTMLElement | undefined;
+  const text = normalizeText(picked?.innerText || '');
+  if (text) return text;
+
+  // Fallback: clone metadata area and strip non-description parts
+  const metadata = document.querySelector('ytd-watch-metadata') as HTMLElement | null;
+  if (metadata) {
+    const clone = metadata.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll([
+      '#owner',
+      'ytd-sentiment-bar-renderer',
+      'ytd-menu-renderer',
+      'ytd-watch-info-text',
+      'ytd-video-primary-info-renderer',
+      'ytd-watch-next-secondary-results-renderer',
+      'button',
+      'svg',
+      'a',
+      '#comments'
+    ].join(','))?.forEach(n => n.remove());
+    const txt = normalizeText(clone.innerText || '');
+    if (txt) return txt;
+  }
+
+  return '';
+}
+
+async function doScrapFromYouTubeButton(): Promise<boolean> {
+  try {
+    const title = extractTitle() || 'YouTube';
+    const url = window.location.href;
+    const main = extractDescription();
+    const content = normalizeText(main);
+
+    if (!content.trim()) return false;
+
+    await browser.runtime.sendMessage({
+      action: 'scrapExtracted',
+      data: { content, title: `YouTube | ${title}`, url }
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function injectButtonNearSubscribe(root: ParentNode = document): void {
+  const found = querySubscribeHost(root);
+  if (!found) return;
+  const { subscribe } = found;
+  const parent = getInjectionParent(subscribe);
+  if (!parent) return;
+  if (!needsInjection(parent)) return;
+
+  const button = createTyquillButton();
+
+  // Delegate click handler here: try structured scrape, fallback to page clip
+  button.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const ok = await doScrapFromYouTubeButton();
+    if (!ok) {
+      try { window.dispatchEvent(new CustomEvent('tyquill:yt-button-click')); } catch {}
+    }
+  }, true);
+
+  try {
+    if (subscribe.nextSibling) {
+      parent.insertBefore(button, subscribe.nextSibling);
+    } else {
+      parent.appendChild(button);
+    }
+  } catch {
+    parent.appendChild(button);
+  }
+
+  // Ensure icon theme is correct after insertion
+  try { applyIconTheme(button); } catch {}
+}
+
+export function initYouTubeInjector(): CleanupFn {
+  if (!isYouTubeSite()) return () => {};
+
+  ensureStylesInjected();
+
+  // Keep global delegated handler for robustness (buttons added later without listeners)
+  const handler = async (e: Event) => {
+    const target = e.target as Element | null;
+    if (!target) return;
+    const btn = target.closest('button[data-tyquill="yt-action"]') as HTMLButtonElement | null;
+    if (!btn) return;
+    e.stopPropagation();
+    const ok = await doScrapFromYouTubeButton();
+    if (!ok) {
+      try { window.dispatchEvent(new CustomEvent('tyquill:yt-button-click')); } catch {}
+    }
+  };
+  document.addEventListener('click', handler, true);
+
+  // React to theme changes
+  try {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onThemeChange = () => { try { applyIconTheme(); } catch {} };
+    if (mq.addEventListener) mq.addEventListener('change', onThemeChange);
+    else if ((mq as any).addListener) (mq as any).addListener(onThemeChange);
+  } catch {}
+
+  // Initial injection attempt
+  try { injectButtonNearSubscribe(document); } catch {}
+  try { applyIconTheme(); } catch {}
+
+  // Observe dynamic changes (SPA navigation and component updates)
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (m.type === 'childList') {
+        m.addedNodes.forEach((node) => {
+          if (!(node instanceof Element)) return;
+          injectButtonNearSubscribe(node);
+          // Also re-check document to be safe on structural changes
+          injectButtonNearSubscribe(document);
+          applyIconTheme(node);
+        });
+      }
+    }
+  });
+  try {
+    observer.observe(document.body, { childList: true, subtree: true });
+  } catch {}
+
+  return () => {
+    try { observer.disconnect(); } catch {}
+    document.removeEventListener('click', handler, true);
+  };
+}


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-341](https://linear.app/chill-mato/issue/CHI-341/)

## 변경 요약
YouTube 페이지에 Tyquill 스크랩 버튼을 주입하는 인젝터를 추가했습니다. 버튼은 `#owner` 내부 `#subscribe-button`과 같은 부모 아래 형제 요소로 삽입되며, 우리 로고 + “스크랩” 텍스트를 표시합니다. 스크랩 시에는 description만 추출하도록 단순화했습니다.

## 주요 변경사항
- YouTube 인젝터 추가 및 초기화 배선
  - `src/utils/youtubeInjector.ts`
    - 버튼 생성/주입: `#owner #subscribe-button`과 같은 부모의 형제로 삽입
    - 버튼 UI: 좌우 패딩 확대(`0 16px`), 기본 배경색 적용, hover 상태 적용, 텍스트 줄바꿈 방지(`white-space: nowrap`) 및 폭 안정화(`min-width: max-content`)
    - 아이콘 색상: YouTube 실제 테마(라이트/다크) 감지 후 아이콘 `filter`를 인라인 `!important`로 강제 적용하여 라이트=검정, 다크=흰색으로 보장
    - 스크랩 로직: `extractDescription()`으로 본문 설명만 추출해 전송
  - `src/content/App.tsx`
    - `initYouTubeInjector` 임포트 및 `useEffect`로 초기화, 클릭 이벤트(`tyquill:yt-button-click`) 처리 배선

- 기타
  - 린트/타입 오류 없음 확인

## 테스트
- [x] 빌드 확인
- [x] YouTube watch 페이지에서 버튼 주입 확인 (owner/subscribe 인접)
- [x] 라이트/다크 테마에서 아이콘 색상 기대 동작 확인 (라이트=검정, 다크=흰색)
- [x] 버튼 클릭 시 description만 스크랩되어 전송됨 확인
- [x] DOM 동적 변화(SPA 네비게이션) 시에도 버튼 유지/재주입 확인

## 스크린샷/데모 (선택)
<img width="981" height="740" alt="image" src="https://github.com/user-attachments/assets/fe307868-5ab8-43d5-8149-5c46200943f3" />
<img width="981" height="740" alt="image" src="https://github.com/user-attachments/assets/51eadad6-f811-42db-8938-df0d72a4110a" />

## 기타 참고사항
- YouTube DOM이 종종 변하므로, `#owner #subscribe-button` 경로 변동 시 셀렉터 보강이 필요할 수 있습니다.
- description 영역이 접힌 상태(“더보기” 미확장)에서는 내용이 짧게 수집될 수 있습니다. 필요한 경우 자동 확장 로직을 추후 추가할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added YouTube support to the content app.
  * Automatically injects a “스크랩” button near the Subscribe area on youtube.com and m.youtube.com.
  * Theme-aware styling (dark/light) for the button and icon.
  * Works across SPA navigation and dynamic page updates.
  * Clicking the button captures the video’s title, description, and URL and sends them to the extension for saving.
  * Includes fallback handling to ensure reliability if extension messaging isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->