### PR TITLE
[FE] Tiptap 편집기 관련 경고 해결

### DIFF
--- a/src/components/sidepanel/Editor/Editor.tsx
+++ b/src/components/sidepanel/Editor/Editor.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEditor, EditorContent, useEditorState, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
-import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import { TextStyle } from '@tiptap/extension-text-style';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { htmlToMarkdown, markdownToHtml } from '../../../utils/markdownConverter';
@@ -588,8 +586,8 @@ const EditorWrapper: React.FC<EditorWrapperProps> = React.memo(({
     return markdownToHtml(markdown);
   }, []);
 
-  const editor = useEditor({
-    extensions: [
+  const extensions = useMemo(() => {
+    const list = [
       TextStyle,
       StarterKit.configure({
         // StarterKit이 이미 Heading을 포함하고 있으므로 추가 설정
@@ -597,12 +595,21 @@ const EditorWrapper: React.FC<EditorWrapperProps> = React.memo(({
           levels: [1, 2, 3, 4, 5, 6],
         },
       }),
-      Underline,
       TextAlign.configure({
         types: ['heading', 'paragraph'],
       }),
-      HorizontalRule,
-    ],
+    ];
+    const seen = new Set<string>();
+    return list.filter((ext: any) => {
+      const name = ext?.name as string | undefined;
+      if (name && seen.has(name)) return false;
+      if (name) seen.add(name);
+      return true;
+    });
+  }, []);
+
+  const editor = useEditor({
+    extensions,
     content: convertMarkdownToHtml(content),
     editable: !readOnly,
     onUpdate: ({ editor }) => {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-267](https://linear.app/chill-mato/issue/CHI-267/)

## 변경 요약
- Tiptap 에디터 초기화 시 발생하던 중복 확장 경고 제거
  - `[tiptap warn]: Duplicate extension names found: ['underline', 'horizontalRule']`

## 주요 변경사항
- `src/components/sidepanel/Editor/Editor.tsx`
  - `@tiptap/extension-horizontal-rule` 제거 (중복 적용 in Starterkit)
  - `@tiptap/extension-underline` 제거 (중복 적용 in Starterkit)
- extension에 useMemo 적용

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인
- [x] 에디터 로드시 콘솔 Duplicate extension 경고 미출력 확인
- [x] 밑줄 토글 동작 확인 (툴바/단축키)
- [x] 구분선 삽입 동작 확인 (버튼/단축키)

## 스크린샷/데모 (선택)
- N/A

## 기타 참고사항
- StarterKit 포함(발췌): document, paragraph, text, heading, blockquote, code, codeBlock, bulletList, orderedList, listItem, horizontalRule, hardBreak, dropcursor, gapcursor, bold, italic, strike, history
- 기능 변경 없음. 경고 제거 및 안정성 개선 목적

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Underline formatting is no longer available in the editor.
  * Horizontal rule insertion has been removed.

* **Refactor**
  * Streamlined editor extension management for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->