### PR TITLE
[CHI-343] 기존 백엔드에서 작업하던 이벤트 트래킹 extension으로 마이그레이션

### DIFF
--- a/docs/analytics-posthog.md
+++ b/docs/analytics-posthog.md
@@ -1,0 +1,48 @@
+PostHog (MV3) Setup
+
+- Library: `posthog-js-lite` (MV3-safe, no DOM requirements)
+- Config: uses `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`, and toggle via `VITE_POSTHOG_ENABLED` from `.env`
+- Persistence: in-memory for the SDK, distinctId persisted in `browser.storage.local`
+- Wired events (tracked client-side):
+  - acquisition_signup_completed (once per user)
+  - activity_scrap_created (on successful scrap create)
+  - activity_ai_draft_completed (on AI draft completion v1/v2/v3)
+
+Usage
+
+- Initialize once per context (background, sidepanel, options, webviewer, or content) where you want to emit events. No code changes required between dev/prod; use env flags.
+
+```ts
+import { posthogClient } from '../src/analytics/posthog'
+
+await posthogClient.init() // reads envs for key/host/enabled/debug
+
+// Later when you want to add events
+posthogClient.capture('event_name', { foo: 'bar' })
+// To identify a logged-in user
+posthogClient.identify(userId, { email })
+```
+
+Notes
+
+- The helper does not auto-capture or send anything by itself.
+- Distinct ID is generated once and stored under `analytics:ph:distinctId` in extension local storage.
+- Enabling behavior:
+  - By default: enabled only in production builds.
+  - Override via env: set `VITE_POSTHOG_ENABLED=true` to enable in dev (or `false` to disable in prod).
+  - Optional debug logs: `VITE_POSTHOG_DEBUG=true`.
+- You can safely import and call `init` from MV3 service worker and any extension page without inline scripts.
+
+Quick setup
+
+- In `tyquill-ext-client/.env.local`:
+
+```
+VITE_POSTHOG_KEY=phc_...
+# optional
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+# enable analytics in dev
+VITE_POSTHOG_ENABLED=true
+# verbose SDK logs
+VITE_POSTHOG_DEBUG=true
+```

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,7 +1,11 @@
 // Background Service Worker for Tyquill Extension
 import { scrapService } from '../src/services/scrapService';
+import { posthogClient, ensureAnonymousIdentity, EVENT_NAMES } from '../src/analytics/posthog';
 import { browser } from 'wxt/browser';
 import type { Browser } from 'wxt/browser';
+
+// Initialize analytics (no event tracking yet)
+posthogClient.init();
 
 export default defineBackground(() => {
   // 사이드패널 상태 (전역)
@@ -103,6 +107,25 @@ export default defineBackground(() => {
       return true;
     }
 
+    if (request.action === 'analytics:capture') {
+      (async () => {
+        try {
+          await posthogClient.init();
+          await ensureAnonymousIdentity();
+          console.log('[analytics] capture (bg):', request.event, request.properties)
+          posthogClient.capture(request.event, request.properties)
+          // give client some time to flush in MV3
+          await new Promise((r) => setTimeout(r, 250))
+          try { await (posthogClient.get() as any)?.flush?.() } catch {}
+          sendResponse({ success: true })
+        } catch (error) {
+          console.error('❌ Background analytics capture error:', error)
+          sendResponse({ success: false, error: (error as Error)?.message })
+        }
+      })()
+      return true;
+    }
+
   });
 
   /**
@@ -186,6 +209,16 @@ export default defineBackground(() => {
         '', // userComment
         tags // tags
       );
+      // Track scrap created directly from background to ensure delivery
+      try {
+        await posthogClient.init();
+        await ensureAnonymousIdentity();
+        posthogClient.capture(EVENT_NAMES.ACTIVITY_SCRAP_CREATED, { source: 'background' })
+        await new Promise((r) => setTimeout(r, 250))
+        try { await (posthogClient.get() as any)?.flush?.() } catch {}
+      } catch (e) {
+        console.warn('Analytics scrap_created failed (bg):', e)
+      }
       
       // 성공 시 sidepanel에 새로고침 알림
       try {

--- a/entrypoints/content.tsx
+++ b/entrypoints/content.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from '../src/content/App';
+import { posthogClient } from '../src/analytics/posthog';
 
 export default defineContentScript({
   matches: ['<all_urls>'],
   main() {
+    // Initialize analytics (no event tracking yet)
+    posthogClient.init();
+
     const root = document.createElement('div');
     root.id = 'tyquill-content-root';
     document.body.appendChild(root);

--- a/entrypoints/editor/main.tsx
+++ b/entrypoints/editor/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import EditorApp from '../../src/components/editor/EditorApp';
+import { posthogClient } from '../../src/analytics/posthog';
+
+// Initialize analytics (no event tracking yet)
+posthogClient.init();
 
 const container = document.getElementById('root');
 if (container) {

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from '../../src/options/App';
+import { posthogClient } from '../../src/analytics/posthog';
+
+// Initialize analytics (no event tracking yet)
+posthogClient.init();
 
 const container = document.getElementById('root');
 const root = createRoot(container!);

--- a/entrypoints/sidepanel/main.tsx
+++ b/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from '../../src/sidepanel/App';
+import { posthogClient } from '../../src/analytics/posthog';
+
+// Initialize analytics (no event tracking yet)
+posthogClient.init();
 
 const container = document.getElementById('root');
 const root = createRoot(container!);

--- a/entrypoints/webviewer/main.tsx
+++ b/entrypoints/webviewer/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import ViewerShell from '../../src/webviewer/App';
+import { posthogClient } from '../../src/analytics/posthog';
+
+// Initialize analytics (no event tracking yet)
+posthogClient.init();
 
 const container = document.getElementById('root');
 if (container) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "wxt": "^0.20.8"
   },
   "dependencies": {
+    "@posthog/core": "^1.0.2",
     "@floating-ui/react": "^0.27.13",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.14",
@@ -76,6 +77,7 @@
     "immer": "^10.1.1",
     "its-fine": "1.2.0",
     "marked": "^16.1.1",
+    "posthog-js-lite": "^4.1.1",
     "quill": "^2.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.13
         version: 0.27.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@posthog/core':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -110,6 +113,9 @@ importers:
       marked:
         specifier: ^16.1.1
         version: 16.1.1
+      posthog-js-lite:
+        specifier: ^4.1.1
+        version: 4.1.1
       quill:
         specifier: ^2.0.3
         version: 2.0.3
@@ -735,6 +741,9 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@posthog/core@1.0.2':
+    resolution: {integrity: sha512-hWk3rUtJl2crQK0WNmwg13n82hnTwB99BT99/XI5gZSvIlYZ1TPmMZE8H2dhJJ98J/rm9vYJ/UXNzw3RV5HTpQ==}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -3508,6 +3517,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js-lite@4.1.1:
+    resolution: {integrity: sha512-0kexCIAGzPdLL4eThryuoTWrhBB+v9FvgF5IY198VzWaA5r5EZCWZDypOQOft42tL+sqrJ/WbBGo+tTmvfUC0g==}
+
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
@@ -5140,6 +5152,8 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@posthog/core@1.0.2': {}
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -8059,6 +8073,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-js-lite@4.1.1: {}
 
   potpack@1.0.2: {}
 

--- a/src/analytics/bridge.ts
+++ b/src/analytics/bridge.ts
@@ -1,0 +1,28 @@
+import { browser } from 'wxt/browser'
+import { EVENT_NAMES, posthogClient } from './posthog'
+
+export async function captureInBackground(event: string, properties?: Record<string, any>): Promise<void> {
+  try {
+    await browser.runtime.sendMessage({ action: 'analytics:capture', event, properties })
+    return
+  } catch {
+    // Fallback to direct capture in current context
+    try {
+      await posthogClient.init()
+      posthogClient.capture(event, properties)
+    } catch {}
+  }
+}
+
+export async function trackAiDraftCompletedBridge(properties?: Record<string, any>): Promise<void> {
+  return captureInBackground(EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED, properties)
+}
+
+export async function trackLoginBridge(properties?: Record<string, any>): Promise<void> {
+  return captureInBackground(EVENT_NAMES.AUTH_LOGIN, properties)
+}
+
+export async function trackScrapCreatedBridge(properties?: Record<string, any>): Promise<void> {
+  return captureInBackground(EVENT_NAMES.ACTIVITY_SCRAP_CREATED, properties)
+}
+

--- a/src/analytics/posthog.ts
+++ b/src/analytics/posthog.ts
@@ -1,0 +1,267 @@
+import PostHog from 'posthog-js-lite'
+type PostHogEventProperties = Record<string, any>
+import { browser } from 'wxt/browser'
+
+// PostHog configuration sourced from Vite envs (WXT uses Vite)
+const PH_API_KEY = (import.meta as any)?.env?.VITE_POSTHOG_KEY as string | undefined
+const PH_HOST = ((import.meta as any)?.env?.VITE_POSTHOG_HOST as string | undefined) || 'https://us.i.posthog.com'
+const MODE = ((import.meta as any)?.env?.MODE as string | undefined) || 'production'
+const PH_ENABLED_ENV = (import.meta as any)?.env?.VITE_POSTHOG_ENABLED as string | undefined
+const PH_DEBUG_ENV = (import.meta as any)?.env?.VITE_POSTHOG_DEBUG as string | undefined
+
+// Parse boolean-like envs ("true"/"1" enable, "false"/"0" disable)
+function parseBoolEnv(v?: string): boolean | undefined {
+  if (v === undefined) return undefined
+  const s = String(v).trim().toLowerCase()
+  if (s === 'true' || s === '1' || s === 'yes' || s === 'y') return true
+  if (s === 'false' || s === '0' || s === 'no' || s === 'n') return false
+  return undefined
+}
+
+const ENV_ENABLED = parseBoolEnv(PH_ENABLED_ENV)
+const ENV_DEBUG = parseBoolEnv(PH_DEBUG_ENV)
+
+// Enabled default: env override takes precedence; else prod-only
+const DEFAULT_ENABLED = ENV_ENABLED ?? (MODE === 'production')
+const DEFAULT_DEBUG = ENV_DEBUG ?? false
+
+const STORAGE_KEY = 'analytics:ph:distinctId'
+
+let client: PostHog | null = null
+let initialized = false
+let lastIdentifiedId: string | null = null
+
+function uuidv4(): string {
+  // RFC4122 v4
+  const buf = new Uint8Array(16)
+  crypto.getRandomValues(buf)
+
+  // Set version and variant bits
+  buf[6] = (buf[6] & 0x0f) | 0x40
+  buf[8] = (buf[8] & 0x3f) | 0x80
+
+  const hex = Array.from(buf, (b) => b.toString(16).padStart(2, '0'))
+  return (
+    hex.slice(0, 4).join('') +
+    '-' +
+    hex.slice(4, 6).join('') +
+    '-' +
+    hex.slice(6, 8).join('') +
+    '-' +
+    hex.slice(8, 10).join('') +
+    '-' +
+    hex.slice(10, 16).join('')
+  )
+}
+
+async function getOrCreateDistinctId(): Promise<string> {
+  try {
+    const stored = await browser.storage.local.get([STORAGE_KEY])
+    const existing = stored?.[STORAGE_KEY]
+    if (typeof existing === 'string' && existing.length > 0) return existing
+  } catch {
+    // ignore and fallback to generating a new one
+  }
+  const id = uuidv4()
+  try {
+    await browser.storage.local.set({ [STORAGE_KEY]: id })
+  } catch {
+    // ignore (best effort persistence)
+  }
+  return id
+}
+
+export type InitOptions = {
+  enabled?: boolean
+  debug?: boolean
+  host?: string
+  apiKey?: string
+}
+
+/**
+ * Prepare a singleton PostHog client for MV3 contexts (service worker, pages, content).
+ * - Uses in-memory persistence to avoid MV3 storage limitations
+ * - Persists distinctId separately in extension storage for stability
+ * - Does not auto-capture or send any events by itself
+ */
+export async function initPostHog(options: InitOptions = {}): Promise<PostHog | null> {
+  if (initialized) return client
+  initialized = true
+
+  const enabled = options.enabled ?? DEFAULT_ENABLED
+  const apiKey = options.apiKey ?? PH_API_KEY
+  const host = options.host ?? PH_HOST
+  const debug = options.debug ?? DEFAULT_DEBUG
+
+  if (!apiKey || !enabled) {
+    client = null
+    return null
+  }
+
+  // Create client with safe defaults for MV3
+  const ph = new PostHog(apiKey, {
+    host,
+    persistence: 'memory',
+    preloadFeatureFlags: false,
+    disableSurveys: true,
+    disabled: !enabled,
+    requestTimeout: 8000,
+    // Flush immediately in MV3 to avoid SW lifecycle drops
+    flushAt: 1,
+    flushInterval: 200,
+  })
+
+  // Prepare a stable, extension-scoped distinctId for later use (without identifying yet)
+  try {
+    await getOrCreateDistinctId()
+  } catch {
+    // ignore
+  }
+
+  if (debug) {
+    try {
+      ;(ph as any).debug?.(true)
+    } catch {}
+  }
+
+  client = ph
+  return ph
+}
+
+export function getPostHog(): PostHog | null {
+  return client
+}
+
+export function isInitialized(): boolean {
+  return !!client
+}
+
+export function capture(event: string, properties?: PostHogEventProperties): void {
+  ;(client as any)?.capture?.(event, properties)
+}
+
+export function identify(distinctId: string, properties?: PostHogEventProperties): void {
+  ;(client as any)?.identify?.(distinctId, properties)
+  try { lastIdentifiedId = distinctId } catch {}
+}
+
+export async function shutdown(timeoutMs?: number): Promise<void> {
+  if (!client) return
+  try {
+    await (client as any).shutdown?.(timeoutMs)
+  } catch {
+    // ignore
+  }
+}
+
+export async function reset(): Promise<void> {
+  if (!client) return
+  try {
+    // keep nothing by default
+    ;(client as any).reset?.()
+  } catch {
+    // ignore
+  }
+}
+
+// =============== Event Names & Helpers ===============
+
+export const EVENT_NAMES = {
+  ACQUISITION_SIGNUP_COMPLETED: 'acquisition_signup_completed',
+  ACTIVITY_SCRAP_CREATED: 'activity_scrap_created',
+  ACTIVITY_AI_DRAFT_COMPLETED: 'activity_ai_draft_completed',
+  AUTH_LOGIN: 'auth_login',
+} as const
+
+export type EventName = typeof EVENT_NAMES[keyof typeof EVENT_NAMES]
+
+// Storage key helper for one-off events per user
+function oneOffKey(name: EventName, id: string) {
+  return `analytics:ph:once:${name}:${id}`
+}
+
+async function markOnce(name: EventName, id: string) {
+  try {
+    await browser.storage.local.set({ [oneOffKey(name, id)]: true })
+  } catch {}
+}
+
+async function isMarked(name: EventName, id: string): Promise<boolean> {
+  try {
+    const r = await browser.storage.local.get([oneOffKey(name, id)])
+    return !!r?.[oneOffKey(name, id)]
+  } catch {
+    return false
+  }
+}
+
+async function tryIdentify(distinctId: string, properties?: PostHogEventProperties) {
+  try {
+    const current = (client as any)?.getDistinctId?.() || null
+    if (lastIdentifiedId === distinctId || current === distinctId) return
+    identify(distinctId, properties)
+    lastIdentifiedId = distinctId
+  } catch {}
+}
+
+// Ensure we have an extension-scoped anonymous identity for capture when user isn't logged in
+export async function ensureAnonymousIdentity(): Promise<string | null> {
+  try {
+    const id = await getOrCreateDistinctId()
+    const current = (client as any)?.getDistinctId?.() || (client as any)?.getAnonymousId?.() || null
+    if (lastIdentifiedId === id || current === id) {
+      return id
+    }
+    // Only identify if the SDK doesn't already have this id
+    try {
+      identify(id)
+      lastIdentifiedId = id
+    } catch {}
+    return id
+  } catch {
+    return null
+  }
+}
+
+async function trackSignupCompleted(distinctId: string, props?: { email?: string; fullName?: string; provider?: string }) {
+  if (!distinctId) return
+  const already = await isMarked(EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED, distinctId)
+  if (already) return
+  await tryIdentify(distinctId, { email: props?.email, fullName: props?.fullName })
+  // Use $set_once to ensure account-level signup attribution across devices
+  capture(EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED, {
+    $set_once: {
+      signed_up: new Date().toISOString(),
+    },
+    provider: props?.provider,
+  })
+  await markOnce(EVENT_NAMES.ACQUISITION_SIGNUP_COMPLETED, distinctId)
+}
+
+function trackScrapCreated(properties?: PostHogEventProperties) {
+  capture(EVENT_NAMES.ACTIVITY_SCRAP_CREATED, properties)
+}
+
+function trackAiDraftCompleted(properties?: PostHogEventProperties) {
+  capture(EVENT_NAMES.ACTIVITY_AI_DRAFT_COMPLETED, properties)
+}
+
+function trackLogin(properties?: PostHogEventProperties) {
+  capture(EVENT_NAMES.AUTH_LOGIN, properties)
+}
+
+export const posthogClient = {
+  init: initPostHog,
+  get: getPostHog,
+  capture,
+  identify,
+  shutdown,
+  reset,
+  events: {
+    EVENT_NAMES,
+    trackSignupCompleted,
+    trackScrapCreated,
+    trackAiDraftCompleted,
+    trackLogin,
+  },
+}

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -5,6 +5,7 @@
  */
 
 import { globalApiClient } from './globalApiClient';
+import { trackAiDraftCompletedBridge } from '../analytics/bridge';
 
 /**
  * 아티클 생성 DTO
@@ -197,11 +198,13 @@ export class ArticleService {
      * AI로 아티클 생성
      * POST /api/v1/articles/generate
      */
-    async generateArticle(generateData: GenerateArticleDto): Promise<GenerateArticleResponse> {
-        return this.apiRequest('/v1/articles/generate', {
+  async generateArticle(generateData: GenerateArticleDto): Promise<GenerateArticleResponse> {
+        try { await trackAiDraftCompletedBridge({ flow: 'v1', trigger: 'request' }) } catch {}
+        const res = await this.apiRequest<GenerateArticleResponse>('/v1/articles/generate', {
             method: 'POST',
             body: JSON.stringify(generateData),
         });
+        return res;
     }
 
     /**
@@ -294,10 +297,12 @@ export class ArticleService {
      * POST /api/v2/articles/generate
      */
     async generateArticleV2(generateData: GenerateArticleV2Dto): Promise<GenerateArticleV2Response> {
-        return this.apiRequest('/v2/articles/generate', {
+        try { await trackAiDraftCompletedBridge({ flow: 'v2', trigger: 'request' }) } catch {}
+        const res = await this.apiRequest<GenerateArticleV2Response>('/v2/articles/generate', {
             method: 'POST',
             body: JSON.stringify(generateData),
         });
+        return res;
     }
 
     /**
@@ -327,7 +332,7 @@ export class ArticleService {
      * @param interval 폴링 간격 (기본: 5초)
      * @returns 완성된 아티클 정보 또는 타임아웃/에러
      */
-    async waitForArticleCompletion(
+  async waitForArticleCompletion(
         articleId: number, 
         maxAttempts: number = 60, 
         interval: number = 5000
@@ -366,10 +371,12 @@ export class ArticleService {
      * POST /api/v3/articles/generate
      */
     async generateArticleV3(generateData: GenerateArticleV3Dto): Promise<GenerateArticleV3Response> {
-        return this.apiRequest('/v3/articles/generate', {
+        try { await trackAiDraftCompletedBridge({ flow: 'v3', trigger: 'request' }) } catch {}
+        const res = await this.apiRequest<GenerateArticleV3Response>('/v3/articles/generate', {
             method: 'POST',
             body: JSON.stringify(generateData),
         });
+        return res;
     }
 
     /**

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -8,6 +8,8 @@
 import { getServerUrl, getApiUrl, getOAuthCallbackUrl, logEnvironmentInfo } from '../config/environment';
 import { browser } from 'wxt/browser';
 import type { Browser } from 'wxt/browser';
+import { posthogClient } from '../analytics/posthog';
+import { trackLoginBridge } from '../analytics/bridge';
 
 export interface User {
   id: string;
@@ -213,6 +215,29 @@ class AuthService {
       this.notifyStateChange();
 
       // console.log('✅ Authentication successful:', authResponse.user.email);
+
+      // Analytics: identify and track signup (once per user)
+      try {
+        await posthogClient.init();
+        posthogClient.identify(authResponse.user.id, {
+          email: authResponse.user.email,
+          fullName: authResponse.user.fullName,
+          provider: authResponse.user.provider,
+        });
+        // Login event (every login)
+        try {
+          await trackLoginBridge({
+            provider: authResponse.user.provider || 'google',
+            method: 'oauth',
+          })
+        } catch {}
+        await posthogClient.events.trackSignupCompleted(authResponse.user.id, {
+          email: authResponse.user.email,
+          fullName: authResponse.user.fullName,
+          provider: authResponse.user.provider,
+        });
+      } catch {}
+
       return authResponse;
     } catch (error) {
       this.authState.isLoading = false;
@@ -345,6 +370,18 @@ class AuthService {
           // console.log('🔐 Token expired, attempting refresh...');
           await this.refreshToken();
         }
+
+        // Analytics: identify existing user on startup for proper attribution
+        try {
+          if (this.authState.isAuthenticated && this.authState.user?.id) {
+            await posthogClient.init();
+            posthogClient.identify(this.authState.user.id, {
+              email: this.authState.user.email,
+              fullName: this.authState.user.fullName,
+              provider: this.authState.user.provider,
+            });
+          }
+        } catch {}
         
         return true;
       }

--- a/src/services/scrapService.ts
+++ b/src/services/scrapService.ts
@@ -7,6 +7,7 @@
 
 import { ScrapResult } from '../utils/webClipper';
 import { globalApiClient } from './globalApiClient';
+import { trackScrapCreatedBridge } from '../analytics/bridge';
 
 /**
  * 스크랩 생성 요청 DTO (기존 서버 엔티티에 맞춤)
@@ -74,6 +75,12 @@ export class ScrapService {
       //   title: scrapData.title,
       //   contentLength: scrapData.content.length,
       // });
+      try {
+        // Avoid double send when running in background service worker
+        if (typeof document !== 'undefined') {
+          await trackScrapCreatedBridge({ source: 'extension' })
+        }
+      } catch {}
 
       const response = await this.apiRequest<ScrapResponse>('/v1/scraps', {
         method: 'POST',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
       48: '/icon48.png',
       128: '/icon128.png'
     },
+    content_security_policy: {
+      extension_pages:
+        "script-src 'self'; object-src 'self'; base-uri 'self'; connect-src 'self' http://localhost:* ws://localhost:* https://us.i.posthog.com https://*.i.posthog.com https://app.posthog.com https://*.posthog.com",
+    },
     side_panel: {
       default_path: 'sidepanel.html'
     },


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: CHI-343 (https://linear.app/chill-mato/issue/CHI-343/)

## 변경 요약

- PostHog 트래킹을 확장 클라이언트로 이관하고, MV3(Service Worker) 환경에서 안정적으로 이벤트가 전송되도록 백그라운드 브리
지/플러시 전략을 추가

## 주요 변경사항

- 환경변수 기반 설정 추가
    - VITE_POSTHOG_KEY, VITE_POSTHOG_HOST, VITE_POSTHOG_ENABLED, VITE_POSTHOG_DEBUG 사용
    - 기본: 프로덕션에서만 활성화, 개발은 VITE_POSTHOG_ENABLED=true로 강제 활성화
- 이벤트 정의/헬퍼 추가
    - EVENT_NAMES: acquisition_signup_completed, activity_scrap_created, activity_ai_draft_completed, auth_login
    - trackSignupCompleted(계정 단위 1회, $set_once), trackLogin, trackScrapCreated, trackAiDraftCompleted
- Identify 중복 방지 및 비로그인 식별 보장
    - ensureAnonymousIdentity()로 비로그인 시에도 안정적 distinctId 보장
    - lastIdentifiedId + SDK의 getDistinctId()로 identify 중복 호출 차단
    - 로그인 시 identify 1회만 전송, signup은 계정 단위 1회 유지($set_once)
- MV3 안정화(전송 신뢰성 개선)
    - PostHog 초기화 시 즉시 플러시 설정: flushAt: 1, flushInterval: 200
    - 백그라운드 브리지(src/analytics/bridge.ts) 추가 → 모든 컨텍스트 이벤트를 SW에서 전송
    - 백그라운드 핸들러(analytics:capture):
    - `init()` + `ensureAnonymousIdentity()` 보장
    - 디버그 로그 출력
    - 250ms 대기 후 `flush()` 시도(가능한 경우)로 idle 드랍 완화
- 이벤트 트리거 시점 및 라우팅 조정
    - AI 초안: v1/v2/v3 “요청 직후” 전송(trigger: 'request')
    - 스크랩: 백그라운드에서 activity_scrap_created 직접 전송
    - 서비스 레이어는 문서 컨텍스트에서만 브리지 호출(중복 방지)
- CSP/HMR 허용
    - wxt.config.ts에 connect-src로 http://localhost:*, ws://localhost:*, PostHog 호스트 추가
- 문서/의존성
    - docs/analytics-posthog.md 업데이트 (env/동작 방식 반영)
    - 의존성 추가: @posthog/core

## 테스트

- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 스크린샷/데모 (선택)

- 해당사항 없음

## 기타 참고사항

- MV3 특성상 SW가 빨리 idle 상태로 전환되어 전송이 드랍될 수 있어, 백그라운드 전송 + 즉시 플러시 + 짧은 대기를 결합해 안정
성을 높임.