### PR TITLE
스크랩 완료 시 confetti + toast 알림 구현

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -283,9 +283,10 @@ async function handleClipAndScrapCurrentPage(sender: Browser.runtime.MessageSend
       '', // userComment
       tags // tags
     );
-    
-    // 성공 시 sidepanel에 새로고침 알림
+
+    // 성공 시 sidepanel과 content script에 알림
     try {
+      // Sidepanel에 메시지 전송
       browser.runtime.sendMessage({
         action: 'scrapCreated',
         data: result
@@ -293,7 +294,17 @@ async function handleClipAndScrapCurrentPage(sender: Browser.runtime.MessageSend
     } catch (error) {
       // sidepanel이 열려있지 않을 수 있으므로 에러 무시
     }
-    
+
+    // Content script에 토스트 표시 메시지 전송
+    try {
+      await browser.tabs.sendMessage(tabId, {
+        action: 'scrapCreated',
+        data: result
+      });
+    } catch (error) {
+      // Content script가 로드되지 않았을 수 있으므로 에러 무시
+    }
+
     return result;
     
   } catch (error) {
@@ -371,7 +382,7 @@ async function handleClipCurrentPageForStyle(sender: Browser.runtime.MessageSend
 }
 
 /**
- * LinkedIn 버튼이 보낸 컨테이너 텍스트를 API로 저장
+ * 플랫폼 인젝터(LinkedIn, X, Reddit 등)가 보낸 컨테이너 텍스트를 API로 저장
  */
 async function handleScrapExtracted(data: { content: string; title?: string; url?: string }) {
   if (!data?.content || !data.content.trim()) {
@@ -394,9 +405,23 @@ async function handleScrapExtracted(data: { content: string; title?: string; url
   const tags: string[] = [];
   const result = await scrapService.quickScrap(scrapResult, '', tags);
 
+  // Sidepanel에 메시지 전송
   try {
     browser.runtime.sendMessage({ action: 'scrapCreated', data: result });
   } catch {}
+
+  // Content script에 토스트 표시 메시지 전송 (현재 활성 탭)
+  try {
+    const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+    if (tabs[0]?.id) {
+      await browser.tabs.sendMessage(tabs[0].id, {
+        action: 'scrapCreated',
+        data: result
+      });
+    }
+  } catch (error) {
+    // Content script가 로드되지 않았을 수 있으므로 에러 무시
+  }
 
   return result;
 }

--- a/src/components/content/ScrapToast/ScrapToast.module.css
+++ b/src/components/content/ScrapToast/ScrapToast.module.css
@@ -1,0 +1,284 @@
+/* ===================================
+   LIQUID GLASS TOAST - APPLE STYLE
+   =================================== */
+
+.toastContainer {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 2147483647; /* Maximum z-index to ensure visibility over all page content */
+  width: 400px;
+  max-width: calc(100vw - 40px);
+
+  /* Entrance animation: fade + slide from right */
+  opacity: 0;
+  transform: translateX(100px) scale(0.95);
+  transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1); /* Elastic ease-out for premium feel */
+  pointer-events: none;
+}
+
+.toastContainer.visible {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  pointer-events: auto;
+}
+
+.toastContainer.leaving {
+  opacity: 0;
+  transform: translateX(100px) scale(0.95);
+  transition: all 0.3s cubic-bezier(0.4, 0, 1, 1); /* Faster exit */
+  pointer-events: none;
+}
+
+.confettiWrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 140px;
+  overflow: visible;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ===================================
+   LIQUID GLASS EFFECT
+   =================================== */
+
+.toast {
+  /* Translucent white background for liquid glass effect */
+  background: rgba(255, 255, 255, 0.75);
+
+  /* Liquid glass blur effect with enhanced color filters */
+  backdrop-filter: blur(20px) contrast(80%) saturate(120%);
+  -webkit-backdrop-filter: blur(20px) contrast(80%) saturate(120%);
+
+  /* Extra large border-radius for pill-like shape */
+  border-radius: 28px;
+
+  /* Multi-layered shadows for depth with specular highlights */
+  box-shadow:
+    /* Soft outer glow */
+    0 20px 60px rgba(0, 0, 0, 0.15),
+    /* Medium shadow for elevation */
+    0 8px 24px rgba(0, 0, 0, 0.12),
+    /* Specular highlights - top left (cool light) */
+    inset 10px 10px 20px rgba(255, 255, 255, 0.2),
+    inset 2px 2px 5px rgba(255, 255, 255, 0.3),
+    /* Specular highlights - bottom right (warm light) */
+    inset -10px -10px 20px rgba(222, 115, 86, 0.05),
+    inset -2px -2px 30px rgba(222, 115, 86, 0.08),
+    /* Refined edge definition */
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+
+  /* Layout */
+  display: flex;
+  align-items: flex-start;
+  padding: 20px;
+  gap: 14px;
+  position: relative;
+  z-index: 1;
+
+  /* Subtle gradient border for liquid glass effect */
+  border: 1px solid rgba(255, 255, 255, 0.5);
+
+  /* Smooth transform transitions */
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover state - subtle lift effect */
+.toast:hover {
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.18),
+    0 10px 28px rgba(0, 0, 0, 0.14),
+    inset 10px 10px 20px rgba(255, 255, 255, 0.25),
+    inset 2px 2px 5px rgba(255, 255, 255, 0.35),
+    inset -10px -10px 20px rgba(222, 115, 86, 0.08),
+    inset -2px -2px 30px rgba(222, 115, 86, 0.1),
+    0 0 0 1px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+/* ===================================
+   ICON - PREMIUM GRADIENT
+   =================================== */
+
+.iconContainer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+
+  /* Brand color gradient - Tyquill coral/salmon */
+  background: linear-gradient(135deg, #DE7356 0%, #E89278 50%, #F2A68A 100%);
+
+  /* Multi-layered glow for depth */
+  box-shadow:
+    /* Vibrant colored glow */
+    0 4px 20px rgba(222, 115, 86, 0.4),
+    /* Soft outer glow */
+    0 2px 10px rgba(222, 115, 86, 0.3),
+    /* Inner highlight for 3D effect */
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+
+  /* Subtle animation on appearance */
+  animation: iconPulse 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes iconPulse {
+  0% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.icon {
+  color: white;
+  font-size: 24px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
+}
+
+/* ===================================
+   CONTENT - HIGH CONTRAST TEXT
+   =================================== */
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0; /* Allow text truncation */
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1a1a1a;
+  line-height: 1.3;
+  letter-spacing: -0.02em; /* Tighter tracking for Apple feel */
+
+  /* Subtle text shadow for depth */
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
+}
+
+.pageTitle {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(26, 26, 26, 0.75);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+
+  /* Subtle glow for readability */
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.3);
+}
+
+.url {
+  font-size: 12px;
+  color: rgba(26, 26, 26, 0.5);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
+  letter-spacing: -0.01em;
+}
+
+/* ===================================
+   RESPONSIVE DESIGN - MOBILE
+   =================================== */
+
+@media (max-width: 480px) {
+  .toastContainer {
+    top: 16px;
+    right: 16px;
+    width: calc(100vw - 32px);
+  }
+
+  .toast {
+    padding: 16px;
+    gap: 12px;
+    border-radius: 18px;
+  }
+
+  .iconContainer {
+    width: 36px;
+    height: 36px;
+  }
+
+  .icon {
+    font-size: 20px;
+  }
+
+  .title {
+    font-size: 15px;
+  }
+
+  .pageTitle {
+    font-size: 13px;
+  }
+
+  .url {
+    font-size: 11px;
+  }
+}
+
+/* ===================================
+   ACCESSIBILITY & REDUCED MOTION
+   =================================== */
+
+/* Respect user's motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .toastContainer {
+    transition: opacity 0.2s ease;
+  }
+
+  .toastContainer.visible {
+    transform: none;
+  }
+
+  .toastContainer.leaving {
+    transform: none;
+  }
+
+  .iconContainer {
+    animation: none;
+  }
+
+  .toast:hover {
+    transform: none;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .toast {
+    background: rgba(255, 255, 255, 0.95);
+    border: 2px solid rgba(0, 0, 0, 0.3);
+  }
+
+  .title,
+  .pageTitle {
+    color: #000000;
+  }
+
+  .url {
+    color: rgba(0, 0, 0, 0.7);
+  }
+}

--- a/src/components/content/ScrapToast/ScrapToast.tsx
+++ b/src/components/content/ScrapToast/ScrapToast.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+import styles from './ScrapToast.module.css';
+import Confetti from '../../sidepanel/Confetti/Confetti';
+
+interface ScrapToastProps {
+  title: string;
+  url?: string;
+  onClose: () => void;
+  duration?: number;
+}
+
+const ScrapToast: React.FC<ScrapToastProps> = ({
+  title,
+  url,
+  onClose,
+  duration = 4000,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(true);
+
+  useEffect(() => {
+    // 컴포넌트 마운트 후 애니메이션 시작
+    const timer = setTimeout(() => setIsVisible(true), 10);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    // Confetti는 2초 후 숨김
+    const confettiTimer = setTimeout(() => {
+      setShowConfetti(false);
+    }, 2000);
+
+    // Toast는 duration 후 닫힘
+    if (duration > 0) {
+      const timer = setTimeout(() => {
+        handleClose();
+      }, duration);
+      return () => {
+        clearTimeout(timer);
+        clearTimeout(confettiTimer);
+      };
+    }
+
+    return () => clearTimeout(confettiTimer);
+  }, [duration]);
+
+  const handleClose = () => {
+    setIsLeaving(true);
+    setTimeout(() => {
+      onClose();
+    }, 300); // 애니메이션 시간과 맞춤
+  };
+
+  return (
+    <div
+      className={`${styles.toastContainer} ${isVisible ? styles.visible : ''} ${isLeaving ? styles.leaving : ''}`}
+    >
+      {/* Confetti Effect */}
+      {showConfetti && (
+        <div className={styles.confettiWrapper}>
+          <Confetti
+            particleCount={60}
+            durationMs={2000}
+            colors={['#DE7356', '#E89278', '#F2A68A', '#FFC4B0', '#FFD9CC']}
+          />
+        </div>
+      )}
+
+      {/* Toast Content */}
+      <div className={styles.toast}>
+        <div className={styles.iconContainer}>
+          <IoCheckmarkCircle className={styles.icon} />
+        </div>
+        <div className={styles.content}>
+          <div className={styles.title}>스크랩 완료!</div>
+          <div className={styles.pageTitle}>{title}</div>
+          {url && <div className={styles.url}>{url}</div>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScrapToast;

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { useLanguageStore } from '../stores/languageStore';
 import FloatingButton from '../components/content/FloatingButton/FloatingButton';
+import ScrapToast from '../components/content/ScrapToast/ScrapToast';
 import { WebClipper } from '../utils/webClipper';
 import { initLinkedInInjector } from '../utils/linkedinInjector';
 import { clipAndScrapCurrentPage } from '../utils/scrapHelper';
@@ -10,8 +11,15 @@ import { initYouTubeInjector } from '../utils/youtubeInjector';
 import { initXInjector } from '../utils/xInjector';
 import { initRedditInjector } from '../utils/redditInjector';
 
+interface ScrapData {
+  title: string;
+  url?: string;
+}
+
 const App: React.FC = () => {
   const { initializeLanguage } = useLanguageStore();
+  const [showScrapToast, setShowScrapToast] = useState(false);
+  const [scrapData, setScrapData] = useState<ScrapData | null>(null);
   const isThreads = (typeof window !== 'undefined') && (
     window.location.hostname.includes('threads.net') ||
     window.location.hostname.includes('threads.com') ||
@@ -115,6 +123,26 @@ const App: React.FC = () => {
       if (request.type === 'PING') {
         if (sendResponse) {
           sendResponse({ success: true });
+        }
+        return true;
+      }
+
+      // 스크랩 완료 알림 처리
+      if (request.action === 'scrapCreated') {
+        try {
+          const { data } = request;
+          if (data) {
+            setScrapData({
+              title: data.title || data.url || '페이지',
+              url: data.url,
+            });
+            setShowScrapToast(true);
+          }
+          if (sendResponse) {
+            sendResponse({ success: true });
+          }
+        } catch (error) {
+          console.error('❌ 스크랩 알림 표시 실패:', error);
         }
         return true;
       }
@@ -244,6 +272,18 @@ const App: React.FC = () => {
   return (
     <div id="tyquill-main-app" className="tyquill-main-root">
       <FloatingButton />
+
+      {/* 스크랩 완료 토스트 알림 */}
+      {showScrapToast && scrapData && (
+        <ScrapToast
+          title={scrapData.title}
+          url={scrapData.url}
+          onClose={() => {
+            setShowScrapToast(false);
+            setScrapData(null);
+          }}
+        />
+      )}
 
       {/* 향후 확장을 위한 추가 컴포넌트들을 위한 컨테이너 */}
       <div id="tyquill-main-components" style={{ display: 'none' }}>

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -462,7 +462,17 @@ export default defineBackground(() => {
           void browser.runtime.lastError;
         }
       }
-      
+
+      // Send toast notification to content script
+      try {
+        await browser.tabs.sendMessage(tabId, {
+          action: 'scrapCreated',
+          data: result
+        });
+      } catch (error) {
+        // Content script may not be loaded
+      }
+
       return result;
       
     } catch (error) {
@@ -578,6 +588,19 @@ export default defineBackground(() => {
       if (browser.runtime.lastError) {
         void browser.runtime.lastError;
       }
+    }
+
+    // Send toast notification to content script (current active tab)
+    try {
+      const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+      if (tabs[0]?.id) {
+        await browser.tabs.sendMessage(tabs[0].id, {
+          action: 'scrapCreated',
+          data: result
+        });
+      }
+    } catch (error) {
+      // Content script may not be loaded
     }
 
     return result;


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-383](https://linear.app/chill-mato/issue/CHI-383/)

## 변경 요약
스크랩 완료 시 Apple 스타일의 liquid glass 디자인 토스트 알림과 confetti 애니메이션을 표시합니다.

## 주요 변경사항
- **ScrapToast 컴포넌트 추가**
  - Apple 스타일의 glassmorphism 효과 적용
  - 브랜드 컬러(Tyquill coral/salmon #DE7356) 사용
  - Confetti 애니메이션 통합 (2초간 표시)
  - 4초 후 자동 닫힘
  - 28px border-radius로 둥근 pill 형태

- **Content Script 통합**
  - App.tsx에 ScrapToast 컴포넌트 추가
  - 'scrapCreated' 메시지 리스너 구현

- **Background Script 메시지 전달**
  - browser.tabs.sendMessage로 content script에 알림
  - handleClipAndScrapCurrentPage 함수 수정
  - handleScrapExtracted 함수 수정

- **모든 스크랩 소스에서 동작**
  - FloatingButton
  - LinkedIn, X, Reddit, Threads, YouTube injectors

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인
  - FloatingButton에서 스크랩 시 토스트 표시 확인
  - 각 플랫폼 injector에서 스크랩 시 토스트 표시 확인
  - Confetti 애니메이션 정상 동작 확인
  - 4초 후 자동 닫힘 확인

## 스크린샷/데모 (선택)
<!-- 토스트 알림 스크린샷 첨부 예정 -->

## 기타 참고사항
- CSS에서 liquid glass 효과를 위해 backdrop-filter 사용
- Close 버튼은 제거하고 auto-dismiss만 사용
- 디버깅용 console.log는 모두 제거됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * After creating or extracting a scrap, you’ll now see a confirmation toast on the current page.
  * Notifications also appear when using clip-and-scrap and extraction flows, even if the side panel isn’t open.

* **Style**
  * Introduced a polished “Liquid Glass” toast with subtle animations, confetti, and iconography.
  * Responsive layout with accessibility considerations (reduced motion and high-contrast support).
  * Smooth entrance/exit transitions and hover elevation for a premium feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->