### PR TITLE
[CHI-390] TipTap JSON 포맷 지원 및 에디터 블록 단위 편집 개선

### DIFF
--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { browser } from 'wxt/browser';
 import { articleService, UpdateArticleDto } from '../../services/articleService';
 import EditorWrapper from '../sidepanel/Editor/Editor';
-import { markdownToHtml } from '../../utils/markdownConverter';
 import { IoSave, IoClose, IoArrowBack } from 'react-icons/io5';
 import { trackPageViewBridge, trackPageExitBridge, trackArchiveEditStartedBridge, trackArchiveEditSavedBridge, trackArchiveEditCancelledBridge, trackArchiveFullscreenEditorOpenedBridge } from '../../analytics/bridge';
 import { useI18n } from '../../hooks/useI18n';
@@ -13,8 +12,10 @@ interface EditorData {
   articleId: number;
   title: string;
   content: string;
+  contentFormat?: 'markdown' | 'tiptap-json';
   originalTitle: string;
   originalContent: string;
+  originalContentFormat?: 'markdown' | 'tiptap-json';
 }
 
 const EditorApp: React.FC = () => {
@@ -22,7 +23,8 @@ const EditorApp: React.FC = () => {
   const { initializeLanguage } = useLanguageStore();
   const [editorData, setEditorData] = useState<EditorData | null>(null);
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | object>('');
+  const [contentFormat, setContentFormat] = useState<'markdown' | 'tiptap-json'>('markdown');
   const [saving, setSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
   const [canUndo, setCanUndo] = useState(false);
@@ -51,7 +53,22 @@ const EditorApp: React.FC = () => {
           
           setEditorData(data);
           setTitle(data.title);
-          setContent(data.content);
+
+          // Parse content based on format
+          const format = data.contentFormat || 'markdown';
+          setContentFormat(format);
+
+          if (format === 'tiptap-json' && typeof data.content === 'string') {
+            try {
+              setContent(JSON.parse(data.content));
+            } catch (error) {
+              console.warn('Failed to parse TipTap JSON, falling back to markdown:', error);
+              setContent(data.content);
+              setContentFormat('markdown');
+            }
+          } else {
+            setContent(data.content);
+          }
 
           // Track fullscreen editor opened event
           trackArchiveFullscreenEditorOpenedBridge({
@@ -149,11 +166,18 @@ const EditorApp: React.FC = () => {
   // 변경사항 감지
   useEffect(() => {
     if (!editorData) return;
-    
-    const contentChanged = title !== editorData.originalTitle || content !== editorData.originalContent;
+
+    // Serialize content for comparison
+    const currentContent = typeof content === 'string'
+      ? content
+      : JSON.stringify(content);
+
+    const titleChanged = title !== editorData.originalTitle;
+    const contentChanged = currentContent !== editorData.originalContent;
+
     // 컨텐츠가 변경되었고 실행 취소가 가능한 경우에만 hasChanges를 true로 설정
     // 실행 취소가 불가능하면 초기 상태로 돌아간 것으로 간주
-    const hasChanged = contentChanged && canUndo;
+    const hasChanged = (titleChanged || contentChanged) && canUndo;
     setHasChanges(hasChanged);
   }, [title, content, editorData, canUndo]);
 
@@ -180,12 +204,20 @@ const EditorApp: React.FC = () => {
     try {
       setSaving(true);
 
-      // 저장 전에 콘텐츠 정리
-      const normalizedContent = content.replace(/\n{2,}/g, '\n').trim();
+      // Serialize content based on type
+      let serializedContent: string;
+      if (typeof content === 'string') {
+        // Markdown content - normalize whitespace
+        serializedContent = content.replace(/\n{2,}/g, '\n').trim();
+      } else {
+        // TipTap JSON object - stringify
+        serializedContent = JSON.stringify(content);
+      }
 
       const updateData: UpdateArticleDto = {
         title: title.trim(),
-        content: normalizedContent,
+        content: serializedContent,
+        contentFormat: contentFormat,
       };
 
       await articleService.updateArticle(editorData.articleId, updateData);
@@ -194,9 +226,9 @@ const EditorApp: React.FC = () => {
       trackArchiveEditSavedBridge({
         article_id: editorData.articleId,
         article_title: title.trim(),
-        content_length: normalizedContent.length,
+        content_length: serializedContent.length,
         title_changed: title.trim() !== editorData.originalTitle,
-        content_changed: normalizedContent !== editorData.originalContent,
+        content_changed: serializedContent !== editorData.originalContent,
         editor_type: 'fullscreen',
         session_duration: Math.round((Date.now() - pageStartTimeRef.current) / 1000)
       }).catch(() => {});
@@ -204,7 +236,7 @@ const EditorApp: React.FC = () => {
       // 저장 성공 시 변경사항 플래그 및 실행 취소 상태 초기화
       setHasChanges(false);
       setCanUndo(false);
-      
+
       // storage에 저장 완료 신호 보내기
       browser.storage.local.set({
         [`tyquill-editor-saved-${editorData.articleId}`]: {
@@ -212,19 +244,19 @@ const EditorApp: React.FC = () => {
           timestamp: Date.now()
         }
       });
-      
+
       // 잠시 후 페이지 닫기
       setTimeout(() => {
         window.close();
       }, 500);
-      
+
     } catch (error: any) {
       console.error('Save failed:', error);
       alert(`Save failed: ${error.message || 'Unknown error'}`);
     } finally {
       setSaving(false);
     }
-  }, [editorData, title, content]);
+  }, [editorData, title, content, contentFormat]);
 
   const handleCancel = useCallback(() => {
     if (hasChanges) {
@@ -234,11 +266,16 @@ const EditorApp: React.FC = () => {
 
     // Track cancel event
     if (editorData) {
+      // Serialize content for comparison
+      const currentContent = typeof content === 'string'
+        ? content
+        : JSON.stringify(content);
+
       trackArchiveEditCancelledBridge({
         article_id: editorData.articleId,
         had_changes: hasChanges,
         title_changed: title !== editorData.originalTitle,
-        content_changed: content !== editorData.originalContent,
+        content_changed: currentContent !== editorData.originalContent,
         editor_type: 'fullscreen',
         session_duration: Math.round((Date.now() - pageStartTimeRef.current) / 1000)
       }).catch(() => {});
@@ -263,6 +300,12 @@ const EditorApp: React.FC = () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
+
+  // 에디터 변경 핸들러
+  const handleEditorChange = useCallback((newContent: string | object, format: 'markdown' | 'tiptap-json') => {
+    setContent(newContent);
+    setContentFormat(format);
+  }, []);
 
   // 히스토리 상태 변경 핸들러
   const handleHistoryStateChange = useCallback((canUndoState: boolean, canRedoState: boolean) => {
@@ -318,8 +361,9 @@ const EditorApp: React.FC = () => {
       <div className={styles.editorSection}>
         <div className={styles.editorWrapper}>
           <EditorWrapper
-            content={markdownToHtml(content)}
-            onChange={setContent}
+            content={content}
+            contentFormat={contentFormat}
+            onChange={handleEditorChange}
             placeholder="Enter content..."
             readOnly={saving}
             onHistoryStateChange={handleHistoryStateChange}

--- a/src/utils/markdownConverter.ts
+++ b/src/utils/markdownConverter.ts
@@ -189,32 +189,48 @@ const getTextContent = (element: Element): string => {
 export const markdownToHtml = (markdown: string): string => {
   if (!markdown) return '';
 
-  // 간단한 마크다운 to HTML 변환
-  return markdown
-    // 수평선 처리 (---, ***, ___) - 줄바꿈 처리 전에 해야 함
-    .replace(/^---\s*$/gm, '<hr>')
-    .replace(/^\*\*\*\s*$/gm, '<hr>')
-    .replace(/^___\s*$/gm, '<hr>')
-    // 헤딩
-    .replace(/^### (.*$)/gim, '<h3>$1</h3>')
-    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-    // 볼드
-    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-    // 이탤릭
-    .replace(/\*(.*?)\*/g, '<em>$1</em>')
-    // 취소선
-    .replace(/~~(.*?)~~/g, '<del>$1</del>')
-    // 밑줄
-    .replace(/__(.*?)__/g, '<u>$1</u>')
-    // 인라인 코드
-    .replace(/`(.*?)`/g, '<code>$1</code>')
-    // 이미지 처리 먼저: ![alt](url) → <img>
-    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />')
-    // 링크 처리: [text](url) - 이미지가 아닌 경우만 (! 로 시작하지 않는 경우)
-    .replace(/(?<!\!)\[([^\[\]]+?)\]\(([^)]+?)\)/g, '<a href="$2">$1</a>')
-    // 줄바꿈
-    .replace(/\n/g, '<br>');
+  // Split into lines and process each line separately to create distinct paragraph blocks
+  const lines = markdown.split('\n');
+
+  return lines
+    .map(line => {
+      const trimmed = line.trim();
+      if (!trimmed) return ''; // Skip empty lines
+
+      // Process markdown syntax for this line
+      let processed = trimmed
+        // Horizontal rules FIRST (before other processing)
+        .replace(/^---\s*$/, '<hr>')
+        .replace(/^\*\*\*\s*$/, '<hr>')
+        .replace(/^___\s*$/, '<hr>')
+        // Headings (must be at start of line)
+        .replace(/^### (.+)$/, '<h3>$1</h3>')
+        .replace(/^## (.+)$/, '<h2>$1</h2>')
+        .replace(/^# (.+)$/, '<h1>$1</h1>')
+        // Bullet list items
+        .replace(/^[-*+] (.+)$/, '<ul><li>$1</li></ul>')
+        // Numbered list items
+        .replace(/^(\d+)\. (.+)$/, '<ol><li>$2</li></ol>')
+        // Inline formatting (bold, italic, etc.)
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*(.+?)\*/g, '<em>$1</em>')
+        .replace(/~~(.+?)~~/g, '<del>$1</del>')
+        .replace(/__(.*?)__/g, '<u>$1</u>')
+        .replace(/`(.+?)`/g, '<code>$1</code>')
+        // Images: ![alt](url) → <img>
+        .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />')
+        // Links: [text](url) - negative lookbehind for !
+        .replace(/(?<!\!)\[([^\[\]]+?)\]\(([^)]+?)\)/g, '<a href="$2">$1</a>');
+
+      // Wrap in <p> ONLY if not already a block element
+      if (!processed.match(/^<(h[1-6]|hr|ul|ol|blockquote)/)) {
+        processed = `<p>${processed}</p>`;
+      }
+
+      return processed;
+    })
+    .filter(line => line) // Remove empty strings
+    .join('');
 };
 
 /**


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-390](https://linear.app/chill-mato/issue/CHI-390)

## 변경 요약
에디터가 TipTap JSON 포맷을 지원하고, 마크다운 파싱을 블록 단위로 처리하여 개별 줄 편집이 가능하도록 개선

## 주요 변경사항

### EditorApp.tsx
- content 타입을 string | object로 확장
- contentFormat 상태 추가 (markdown/tiptap-json)
- 로딩/저장 시 포맷에 따라 JSON 파싱/직렬화 처리
- API 요청에 contentFormat 필드 포함

### markdownConverter.ts
- markdownToHtml 함수를 줄 단위 처리로 변경
- 각 줄을 독립된 <p> 블록으로 변환
- 헤딩, 리스트는 적절한 블록 요소로 처리

## 테스트
- [x] 빌드 확인
- [x] 기능 확인

## 기타 참고사항
기존에는 전체 텍스트가 하나의 블록으로 처리되어 부분 편집이 불가능했음. 이제 각 줄을 독립적으로 편집할 수 있어 에디터 사용성이 개선됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor now supports multiple content formats (Markdown and rich-text), with seamless loading and saving.
  * Improved cancel and post-save behavior to better reflect actual content changes.

* **Bug Fixes**
  * More reliable change detection across title and content, avoiding false positives/negatives.
  * Safer content parsing with graceful fallback when loading invalid data.

* **Refactor**
  * Markdown rendering updated to line-based processing for cleaner, more consistent output (headings, lists, links, images, inline styles).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->