### PR TITLE
[CHI-391] 전체화면 에디터 CSS 로딩 및 렌더링 수정

### DIFF
--- a/src/components/editor/EditorApp.module.css
+++ b/src/components/editor/EditorApp.module.css
@@ -147,13 +147,13 @@
   width: 100%;
   max-width: 900px;
   background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
-  overflow: visible;
-  border: 1px solid #e2e8f0;
+  overflow: auto;
   min-height: 600px;
   max-height: calc(100vh - 200px);
+  padding: 0 48px;
 }
+
+/* Remove all style overrides - let NotionEditor handle its own styling */
 
 .loadingContainer {
   display: flex;

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -7,6 +7,8 @@ import { trackPageViewBridge, trackPageExitBridge, trackArchiveEditStartedBridge
 import { useI18n } from '../../hooks/useI18n';
 import { useLanguageStore } from '../../stores/languageStore';
 import styles from './EditorApp.module.css';
+// Import NotionEditor CSS to ensure it's loaded in dev mode
+import '../sidepanel/Editor/NotionEditor.module.css';
 
 interface EditorData {
   articleId: number;
@@ -60,7 +62,8 @@ const EditorApp: React.FC = () => {
 
           if (format === 'tiptap-json' && typeof data.content === 'string') {
             try {
-              setContent(JSON.parse(data.content));
+              const parsedContent = JSON.parse(data.content);
+              setContent(parsedContent);
             } catch (error) {
               console.warn('Failed to parse TipTap JSON, falling back to markdown:', error);
               setContent(data.content);

--- a/src/components/sidepanel/Editor/NotionEditor.tsx
+++ b/src/components/sidepanel/Editor/NotionEditor.tsx
@@ -76,7 +76,7 @@ const NotionEditor: React.FC<NotionEditorProps> = ({
     editable: !readOnly,
     editorProps: {
       attributes: {
-        class: styles.notionEditor,
+        class: 'notionEditor',
       },
     },
     onUpdate: ({ editor }) => {

--- a/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
+++ b/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
@@ -340,10 +340,6 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
 
       // 저장 완료 이벤트 추적
       try {
-        const contentLengthAfter = typeof editContent === 'string'
-          ? editContent.length
-          : JSON.stringify(editContent).length;
-
         await trackArchiveEditSavedBridge({
           article_id: article.articleId,
           previous_version: selectedVersionNumber,
@@ -351,7 +347,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
           content_changed: contentToSave !== (currentArchive?.content || article.content),
           title_changed: editTitle !== (currentArchive?.title || article.title),
           character_count_before: characterCount.characters,
-          character_count_after: contentLengthAfter
+          character_count_after: contentToSave.length
         });
       } catch {}
 
@@ -411,6 +407,11 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
         ? JSON.stringify(originalContent)
         : originalContent;
 
+      // originalContentFormat은 originalContent와 동일한 소스에서 파생
+      const originalContentFormat = currentArchive
+        ? ((currentArchive as any)?.contentFormat || 'markdown')
+        : ((article as any)?.contentFormat || 'markdown');
+
       const editorData = {
         articleId: article.articleId,
         title: editTitle,
@@ -418,7 +419,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
         contentFormat: contentFormat,
         originalTitle: currentArchive?.title || article.title,
         originalContent: originalContentToPass,
-        originalContentFormat: contentFormat
+        originalContentFormat: originalContentFormat
       };
 
       // browser.storage.local을 사용하여 안전하게 데이터 전달 (anchor 링크나 특수 문자 처리)
@@ -753,7 +754,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
                     const html = generateHTML(jsonObj, [
                       StarterKit.configure({
                         heading: {
-                          levels: [1, 2, 3],
+                          levels: [1, 2, 3, 4, 5, 6],
                         },
                         horizontalRule: {
                           HTMLAttributes: {

--- a/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
+++ b/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
@@ -19,6 +19,7 @@ import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
 import { TextStyle } from '@tiptap/extension-text-style';
 import Tooltip from '../../components/common/Tooltip'; // Tooltip 컴포넌트 import
@@ -339,14 +340,18 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
 
       // 저장 완료 이벤트 추적
       try {
+        const contentLengthAfter = typeof editContent === 'string'
+          ? editContent.length
+          : JSON.stringify(editContent).length;
+
         await trackArchiveEditSavedBridge({
           article_id: article.articleId,
           previous_version: selectedVersionNumber,
           new_version: newVersionNumber,
-          content_changed: normalizedContent !== (currentArchive?.content || article.content),
+          content_changed: contentToSave !== (currentArchive?.content || article.content),
           title_changed: editTitle !== (currentArchive?.title || article.title),
           character_count_before: characterCount.characters,
-          character_count_after: editContent.length
+          character_count_after: contentLengthAfter
         });
       } catch {}
 
@@ -393,12 +398,27 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
 
     try {
       // 편집기로 전달할 데이터 준비
+      const archive = currentArchive || article.archives?.[0];
+      const contentFormat = (archive as any)?.contentFormat || 'markdown';
+
+      // Content를 문자열로 변환 (JSON 형식이면 stringify)
+      const contentToPass = typeof editContent === 'object'
+        ? JSON.stringify(editContent)
+        : editContent;
+
+      const originalContent = currentArchive?.content || article.content;
+      const originalContentToPass = typeof originalContent === 'object'
+        ? JSON.stringify(originalContent)
+        : originalContent;
+
       const editorData = {
         articleId: article.articleId,
         title: editTitle,
-        content: editContent,
+        content: contentToPass,
+        contentFormat: contentFormat,
         originalTitle: currentArchive?.title || article.title,
-        originalContent: currentArchive?.content || article.content
+        originalContent: originalContentToPass,
+        originalContentFormat: contentFormat
       };
 
       // browser.storage.local을 사용하여 안전하게 데이터 전달 (anchor 링크나 특수 문자 처리)
@@ -729,19 +749,20 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
                   try {
                     const jsonObj = JSON.parse(content);
 
-                    // generateHTML로 JSON을 HTML로 변환
+                    // generateHTML로 JSON을 HTML로 변환 (NotionEditor와 동일한 extensions 사용)
                     const html = generateHTML(jsonObj, [
-                      TextStyle,
                       StarterKit.configure({
                         heading: {
-                          levels: [1, 2, 3, 4, 5, 6],
+                          levels: [1, 2, 3],
                         },
                         horizontalRule: {
                           HTMLAttributes: {
-                            class: 'editor-hr',
+                            class: 'notion-hr',
                           },
                         },
                       }),
+                      TextStyle,
+                      Underline,
                       TextAlign.configure({
                         types: ['heading', 'paragraph'],
                       }),


### PR DESCRIPTION
## 🔗 연관 이슈

Closes: [CHI-391](https://linear.app/chill-mato/issue/CHI-391)

## 변경 요약

전체화면 에디터에서 NotionEditor CSS가 로드되지 않아 렌더링되지 않던 문제를 수정

## 주요 변경사항

- EditorApp.tsx: NotionEditor CSS import 추가하여 전체화면에서 CSS 로딩 보장
- NotionEditor.tsx: 클래스명을 styles.notionEditor → 'notionEditor'로 변경하여 :global(.notionEditor) CSS 선택자와 매칭
- ArchiveDetailPage.tsx: Underline extension 추가 및 contentFormat 필드 전달하여 TipTap 호환성 개선

## 테스트

- [x] 빌드 확인
- [x] 사이드패널 에디터 정상 동작 확인
- [x] 전체화면 에디터 CSS 로딩 확인

## 기타 참고사항

- 사이드패널과 전체화면 에디터가 동일한 NotionEditor 컴포넌트를 사용하므로 일관된 동작 보장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for underline formatting in the editor and rendered content.

* **Style**
  * Updated editor container padding and scrolling for smoother navigation.
  * Applied consistent styling to the Notion-based editor.

* **Bug Fixes**
  * Improved accuracy when detecting content changes after saves.
  * Ensured content format is consistently tracked and passed through edit and display flows.

* **Refactor**
  * Minor cleanup to improve reliability and ensure styles load correctly in development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->