### PR TITLE
[CHI-392] webClipper.ts에서 중복된 extractPlainText 메소드 제거

### DIFF
--- a/src/utils/webClipper.ts
+++ b/src/utils/webClipper.ts
@@ -520,26 +520,6 @@ export class WebClipper {
   }
 
   /**
-   * HTML에서 순수 텍스트 추출
-   */
-  private extractPlainText(html: string): string {
-    // 임시 div 생성
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = html;
-
-    // script, style 태그 제거
-    tempDiv.querySelectorAll('script, style, noscript').forEach(el => el.remove());
-
-    // 텍스트 추출
-    let text = tempDiv.textContent || tempDiv.innerText || '';
-
-    // 모든 개행 문자와 여러 공백을 하나의 공백으로 압축
-    text = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
-
-    return text;
-  }
-
-  /**
    * 페이지 메타데이터 추출
    */
   private extractMetadata(): PageMetadata {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-392](https://linear.app/chill-mato/issue/CHI-392/)

## 변경 요약
webClipper.ts에서 중복 정의된 extractPlainText 메소드 제거

## 주요 변경사항
- `src/utils/webClipper.ts`에서 중복된 `extractPlainText` 메소드 제거
  - 첫 번째 정의 (line 505)를 유지
  - 중복된 두 번째 정의 (line 522-540) 삭제
- TypeScript/빌드 오류 해결

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 기타 참고사항
코드 중복 해결임.