### PR TITLE
[CHI-394] Notion 스타일 풀스크린 에디터 UI 개선 및 버전 히스토리 기능 추가

### DIFF
--- a/src/components/editor/EditorApp.module.css
+++ b/src/components/editor/EditorApp.module.css
@@ -573,6 +573,56 @@
 }
 
 /* ============================================
+   Error Banner
+   ============================================ */
+.errorBanner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: #eb5757;
+  color: white;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 150;
+  animation: slideDown 0.3s ease-out;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.errorText {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.errorCloseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 20px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  outline: none;
+}
+
+.errorCloseButton:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.errorCloseButton:active {
+  transform: scale(0.95);
+}
+
+/* ============================================
    Version Preview Banner
    ============================================ */
 .versionPreviewBanner {

--- a/src/components/editor/EditorApp.module.css
+++ b/src/components/editor/EditorApp.module.css
@@ -1,190 +1,150 @@
+/* ============================================
+   Notion-inspired Editor Container
+   ============================================ */
 .editorContainer {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100vh;
   width: 100vw;
-  background: #fafafa;
+  background: #ffffff;
   overflow: hidden;
 }
 
-.header {
+/* ============================================
+   Action Bar (Top-right corner)
+   ============================================ */
+.actionBar {
+  position: fixed;
+  top: 0;
+  right: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 20px 24px;
-  border-bottom: 1px solid #e5e7eb;
-  background: #ffffff;
-  flex-shrink: 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  gap: 16px;
+  padding: 24px 40px;
+  z-index: 100;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
+  pointer-events: none;
 }
 
-.headerContent {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  max-width: 1200px;
-  gap: 24px;
+.statusIndicator {
+  pointer-events: auto;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.titleSection {
-  flex: 1;
-  min-width: 0;
+.savedStatus {
+  color: rgba(55, 53, 47, 0.5);
+  opacity: 0;
+  animation: fadeInOut 2s ease-in-out;
 }
 
-.titleInput {
-  width: 100%;
-  font-size: 28px;
-  font-weight: 700;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: #111827;
-  padding: 12px 0;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s ease;
-  line-height: 1.2;
+.unsavedStatus {
+  color: rgba(55, 53, 47, 0.7);
 }
 
-.titleInput:focus {
-  border-bottom-color: #3b82f6;
+.savingStatus {
+  color: rgba(55, 53, 47, 0.7);
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
-.titleInput::placeholder {
-  color: #9ca3af;
-  font-weight: 400;
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .actionButtons {
   display: flex;
-  gap: 12px;
-  flex-shrink: 0;
-}
-
-.saveButton {
-  display: flex;
-  align-items: center;
   gap: 8px;
-  padding: 12px 20px;
-  background: #f8f9fa;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  color: #64748b;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  pointer-events: auto;
 }
 
-.saveButton:hover:not(:disabled) {
-  background: #f1f5f9;
-  border-color: #cbd5e1;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.saveButton.hasChanges {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  border-color: #3b82f6;
-  color: white;
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
-}
-
-.saveButton.hasChanges:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  border-color: #2563eb;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
-}
-
-.saveButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-
+.saveButton,
 .cancelButton {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 20px;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  color: #64748b;
-  font-size: 14px;
-  font-weight: 600;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: rgba(55, 53, 47, 0.7);
   cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+
+.saveButton:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.08);
+  color: rgb(55, 53, 47);
+}
+
+.saveButton:active:not(:disabled) {
+  background: rgba(55, 53, 47, 0.12);
+  transform: scale(0.95);
+}
+
+.saveButton:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .cancelButton:hover:not(:disabled) {
-  background: #f8fafc;
-  border-color: #cbd5e1;
-  color: #475569;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: rgba(55, 53, 47, 0.08);
+  color: rgb(55, 53, 47);
+}
+
+.cancelButton:active:not(:disabled) {
+  background: rgba(55, 53, 47, 0.12);
+  transform: scale(0.95);
 }
 
 .cancelButton:disabled {
-  opacity: 0.5;
+  opacity: 0.3;
   cursor: not-allowed;
-  transform: none;
 }
 
-.editorSection {
-  flex: 1;
-  padding: 32px 24px;
-  overflow: auto;
-  min-height: 0;
-  display: flex;
-  justify-content: center;
-}
-
-.editorWrapper {
+/* ============================================
+   Centered Content Area
+   ============================================ */
+.contentArea {
   width: 100%;
-  max-width: 900px;
-  background: #ffffff;
-  overflow: auto;
-  min-height: 600px;
-  max-height: calc(100vh - 200px);
-  padding: 0 48px;
+  max-width: 750px;
+  margin: 0 auto;
+  padding: 96px 96px 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  animation: fadeIn 0.3s ease-out;
 }
 
-/* Remove all style overrides - let NotionEditor handle its own styling */
-
-.loadingContainer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  font-size: 16px;
-  color: #6b7280;
-}
-
-.changesIndicator {
-  position: fixed;
-  bottom: 32px;
-  right: 32px;
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: white;
-  padding: 12px 20px;
-  border-radius: 25px;
-  font-size: 13px;
-  font-weight: 600;
-  box-shadow: 0 4px 20px rgba(245, 158, 11, 0.4);
-  z-index: 1000;
-  animation: slideIn 0.3s ease;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
-}
-
-@keyframes slideIn {
+@keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(8px);
   }
   to {
     opacity: 1;
@@ -192,75 +152,495 @@
   }
 }
 
-/* 반응형 스타일 */
+/* ============================================
+   Large Title Input (Notion-style)
+   ============================================ */
+.titleInput {
+  width: 100%;
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: rgb(55, 53, 47);
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0;
+  margin: 0 0 4px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+  resize: none;
+  overflow: hidden;
+  transition: color 0.2s ease;
+}
+
+.titleInput:focus {
+  color: rgb(55, 53, 47);
+}
+
+.titleInput::placeholder {
+  color: rgba(55, 53, 47, 0.3);
+  font-weight: 700;
+}
+
+/* ============================================
+   Editor Wrapper (Seamless integration)
+   ============================================ */
+.editorWrapper {
+  width: 100%;
+  margin-top: 8px;
+  color: rgb(55, 53, 47);
+  font-size: 16px;
+  line-height: 1.5;
+  animation: fadeIn 0.4s ease-out 0.1s backwards;
+}
+
+/* Remove all borders and backgrounds from editor */
+.editorWrapper :global(.ProseMirror) {
+  outline: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-height: 500px;
+}
+
+.editorWrapper :global(.ProseMirror p.is-editor-empty:first-child::before) {
+  color: rgba(55, 53, 47, 0.3);
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
+/* ============================================
+   Loading State
+   ============================================ */
+.loadingContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  font-size: 14px;
+  color: rgba(55, 53, 47, 0.4);
+  font-weight: 500;
+}
+
+/* ============================================
+   Responsive Design
+   ============================================ */
+
+/* Tablet and smaller laptops */
 @media (max-width: 1024px) {
-  .editorWrapper {
-    max-width: 800px;
+  .contentArea {
+    max-width: 680px;
+    padding: 80px 64px 160px;
+  }
+
+  .actionBar {
+    padding: 20px 32px;
   }
 }
 
+/* Tablet portrait and mobile landscape */
 @media (max-width: 768px) {
-  .header {
-    padding: 16px 20px;
-  }
-  
-  .headerContent {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 16px;
-  }
-  
-  .titleInput {
-    font-size: 24px;
-    text-align: center;
-  }
-  
-  .actionButtons {
-    justify-content: center;
-    gap: 16px;
-  }
-  
-  .saveButton,
-  .cancelButton {
-    flex: 1;
-    justify-content: center;
-    max-width: 150px;
-  }
-  
-  .editorSection {
-    padding: 20px 16px;
-  }
-  
-  .editorWrapper {
+  .contentArea {
     max-width: 100%;
-    margin: 0;
-    border-radius: 8px;
+    padding: 64px 40px 120px;
   }
-  
-  .changesIndicator {
-    bottom: 20px;
-    right: 20px;
-    left: 20px;
-    text-align: center;
+
+  .titleInput {
+    font-size: 32px;
+  }
+
+  .actionBar {
+    padding: 16px 24px;
+  }
+
+  .editorWrapper {
+    font-size: 15px;
   }
 }
 
+/* Mobile portrait */
 @media (max-width: 480px) {
-  .header {
-    padding: 12px 16px;
+  .contentArea {
+    padding: 48px 24px 100px;
   }
-  
+
   .titleInput {
-    font-size: 20px;
+    font-size: 28px;
   }
-  
+
+  .actionBar {
+    padding: 12px 16px;
+    gap: 12px;
+  }
+
+  .statusIndicator {
+    font-size: 12px;
+    padding: 4px 8px;
+  }
+
   .saveButton,
   .cancelButton {
-    padding: 10px 16px;
-    font-size: 13px;
+    width: 28px;
+    height: 28px;
   }
-  
-  .editorSection {
-    padding: 16px 12px;
+
+  .editorWrapper {
+    font-size: 14px;
+  }
+}
+
+/* ============================================
+   Smooth Scrollbar (Notion-like)
+   ============================================ */
+.contentArea::-webkit-scrollbar {
+  width: 8px;
+}
+
+.contentArea::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.contentArea::-webkit-scrollbar-thumb {
+  background: rgba(55, 53, 47, 0.12);
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.contentArea::-webkit-scrollbar-thumb:hover {
+  background: rgba(55, 53, 47, 0.24);
+}
+
+/* Firefox scrollbar */
+.contentArea {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(55, 53, 47, 0.12) transparent;
+}
+
+/* ============================================
+   Version History Button
+   ============================================ */
+.versionHistoryButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: rgba(55, 53, 47, 0.7);
+  cursor: pointer;
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+
+.versionHistoryButton:hover {
+  background: rgba(55, 53, 47, 0.08);
+  color: rgb(55, 53, 47);
+}
+
+.versionHistoryButton:active {
+  background: rgba(55, 53, 47, 0.12);
+  transform: scale(0.95);
+}
+
+/* ============================================
+   Version History Panel
+   ============================================ */
+.versionHistoryBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.1);
+  z-index: 200;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.versionHistoryPanel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 320px;
+  background: #ffffff;
+  border-left: 1px solid rgba(55, 53, 47, 0.09);
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  animation: slideInFromRight 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.04);
+}
+
+@keyframes slideInFromRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* Header */
+.versionHistoryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.09);
+  flex-shrink: 0;
+}
+
+.versionHistoryTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: rgb(55, 53, 47);
+  margin: 0;
+}
+
+.versionHistoryCloseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: rgba(55, 53, 47, 0.6);
+  cursor: pointer;
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  outline: none;
+}
+
+.versionHistoryCloseButton:hover {
+  background: rgba(55, 53, 47, 0.08);
+  color: rgb(55, 53, 47);
+}
+
+/* Content */
+.versionHistoryContent {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.versionHistoryContent::-webkit-scrollbar {
+  width: 6px;
+}
+
+.versionHistoryContent::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.versionHistoryContent::-webkit-scrollbar-thumb {
+  background: rgba(55, 53, 47, 0.12);
+  border-radius: 3px;
+}
+
+.versionHistoryContent::-webkit-scrollbar-thumb:hover {
+  background: rgba(55, 53, 47, 0.24);
+}
+
+/* Loading/Error/Empty states */
+.versionHistoryLoading,
+.versionHistoryError,
+.versionHistoryEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  font-size: 13px;
+  color: rgba(55, 53, 47, 0.5);
+  text-align: center;
+}
+
+.versionHistoryError {
+  color: #eb5757;
+}
+
+/* Version List */
+.versionList {
+  padding: 8px 0;
+}
+
+/* Version Item */
+.versionItem {
+  padding: 12px 20px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  border-left: 3px solid transparent;
+}
+
+.versionItem:hover {
+  background: rgba(55, 53, 47, 0.04);
+}
+
+.versionItemSelected {
+  background: rgba(55, 53, 47, 0.08);
+  border-left-color: rgba(55, 53, 47, 0.8);
+}
+
+.versionItemCurrent {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.versionItemCurrent.versionItemSelected {
+  background: rgba(55, 53, 47, 0.12);
+}
+
+/* Version Item Header */
+.versionItemHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.versionNumber {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  color: rgba(55, 53, 47, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.versionCurrentIcon {
+  color: rgba(55, 53, 47, 0.8);
+}
+
+.versionTime {
+  font-size: 12px;
+  color: rgba(55, 53, 47, 0.6);
+}
+
+/* Version Item Body */
+.versionItemBody {
+  margin-bottom: 8px;
+}
+
+.versionTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgb(55, 53, 47);
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.versionMeta {
+  font-size: 11px;
+  color: rgba(55, 53, 47, 0.5);
+}
+
+/* Restore Button */
+.versionRestoreButton {
+  width: 100%;
+  padding: 6px 12px;
+  margin-top: 8px;
+  background: rgba(55, 53, 47, 0.06);
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 4px;
+  color: rgb(55, 53, 47);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  outline: none;
+}
+
+.versionRestoreButton:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.08);
+  border-color: rgba(55, 53, 47, 0.24);
+}
+
+.versionRestoreButton:active:not(:disabled) {
+  background: rgba(55, 53, 47, 0.12);
+  transform: scale(0.98);
+}
+
+.versionRestoreButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ============================================
+   Version Preview Banner
+   ============================================ */
+.versionPreviewBanner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(55, 53, 47, 0.95);
+  color: white;
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 150;
+  animation: slideDown 0.3s ease-out;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.versionPreviewText {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.versionPreviewActions {
+  display: flex;
+  gap: 8px;
+}
+
+.backToCurrentButton {
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  outline: none;
+}
+
+.backToCurrentButton:hover {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.backToCurrentButton:active {
+  transform: scale(0.98);
+}
+
+/* ============================================
+   Responsive Design for Version History
+   ============================================ */
+
+/* Mobile portrait */
+@media (max-width: 480px) {
+  .versionHistoryPanel {
+    width: 100%;
+    max-width: 100%;
   }
 }

--- a/src/components/editor/EditorApp.module.css
+++ b/src/components/editor/EditorApp.module.css
@@ -644,3 +644,168 @@
     max-width: 100%;
   }
 }
+
+/* ============================================
+   Confirm Modal
+   ============================================ */
+.confirmModalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.confirmModalContent {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-width: 440px;
+  width: 90%;
+  animation: scaleIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.confirmModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.09);
+}
+
+.confirmModalTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: rgb(55, 53, 47);
+  margin: 0;
+}
+
+.confirmModalCloseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: rgba(55, 53, 47, 0.6);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  outline: none;
+}
+
+.confirmModalCloseButton:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.08);
+  color: rgb(55, 53, 47);
+}
+
+.confirmModalCloseButton:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.confirmModalBody {
+  padding: 20px 24px;
+}
+
+.confirmModalMessage {
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgb(55, 53, 47);
+  margin: 0 0 12px 0;
+  font-weight: 500;
+}
+
+.confirmModalInfo {
+  font-size: 13px;
+  line-height: 1.5;
+  color: rgba(55, 53, 47, 0.6);
+  margin: 0;
+}
+
+.confirmModalFooter {
+  display: flex;
+  gap: 8px;
+  padding: 16px 24px 20px;
+  justify-content: flex-end;
+}
+
+.confirmModalCancelButton,
+.confirmModalConfirmButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  outline: none;
+  border: none;
+}
+
+.confirmModalCancelButton {
+  background: transparent;
+  color: rgba(55, 53, 47, 0.7);
+  border: 1px solid rgba(55, 53, 47, 0.16);
+}
+
+.confirmModalCancelButton:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.04);
+  border-color: rgba(55, 53, 47, 0.24);
+}
+
+.confirmModalConfirmButton {
+  background: rgb(55, 53, 47);
+  color: white;
+}
+
+.confirmModalConfirmButton:hover:not(:disabled) {
+  background: rgb(35, 33, 27);
+}
+
+.confirmModalConfirmButton:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.confirmModalCancelButton:disabled,
+.confirmModalConfirmButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 480px) {
+  .confirmModalContent {
+    width: 95%;
+    max-width: 95%;
+  }
+
+  .confirmModalHeader {
+    padding: 16px 20px 12px;
+  }
+
+  .confirmModalBody {
+    padding: 16px 20px;
+  }
+
+  .confirmModalFooter {
+    padding: 12px 20px 16px;
+  }
+}

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { browser } from 'wxt/browser';
-import { articleService, UpdateArticleDto } from '../../services/articleService';
+import { articleService, UpdateArticleDto, VersionHistoryItem } from '../../services/articleService';
 import EditorWrapper from '../sidepanel/Editor/Editor';
-import { IoSave, IoClose, IoArrowBack } from 'react-icons/io5';
+import VersionHistoryPanel from './VersionHistoryPanel';
+import { IoSave, IoClose, IoArrowBack, IoTimeOutline } from 'react-icons/io5';
 import { trackPageViewBridge, trackPageExitBridge, trackArchiveEditStartedBridge, trackArchiveEditSavedBridge, trackArchiveEditCancelledBridge, trackArchiveFullscreenEditorOpenedBridge } from '../../analytics/bridge';
 import { useI18n } from '../../hooks/useI18n';
 import { useLanguageStore } from '../../stores/languageStore';
+import { formatRelativeTime } from '../../utils/timeFormat';
 import styles from './EditorApp.module.css';
 // Import NotionEditor CSS to ensure it's loaded in dev mode
 import '../sidepanel/Editor/NotionEditor.module.css';
@@ -31,6 +33,11 @@ const EditorApp: React.FC = () => {
   const [hasChanges, setHasChanges] = useState(false);
   const [canUndo, setCanUndo] = useState(false);
   const pageStartTimeRef = useRef<number>(Date.now());
+
+  // Version history state
+  const [showVersionHistory, setShowVersionHistory] = useState(false);
+  const [previewingVersion, setPreviewingVersion] = useState<VersionHistoryItem | null>(null);
+  const [currentVersionNumber, setCurrentVersionNumber] = useState<number | undefined>(undefined);
 
   // 언어 설정 초기화
   useEffect(() => {
@@ -248,11 +255,6 @@ const EditorApp: React.FC = () => {
         }
       });
 
-      // 잠시 후 페이지 닫기
-      setTimeout(() => {
-        window.close();
-      }, 500);
-
     } catch (error: any) {
       console.error('Save failed:', error);
       alert(`Save failed: ${error.message || 'Unknown error'}`);
@@ -287,15 +289,125 @@ const EditorApp: React.FC = () => {
     window.close();
   }, [hasChanges, editorData, title, content]);
 
+  // Version history handlers
+  const handleVersionSelect = useCallback((version: VersionHistoryItem) => {
+    // Preview the selected version
+    setPreviewingVersion(version);
+    setTitle(version.title);
+
+    // Parse content based on format
+    if (version.contentFormat === 'tiptap-json') {
+      try {
+        const parsedContent = JSON.parse(version.content);
+        setContent(parsedContent);
+        setContentFormat('tiptap-json');
+      } catch (error) {
+        console.warn('Failed to parse TipTap JSON, using as markdown:', error);
+        setContent(version.content);
+        setContentFormat('markdown');
+      }
+    } else {
+      setContent(version.content);
+      setContentFormat('markdown');
+    }
+  }, []);
+
+  const handleVersionRestore = useCallback(async (version: VersionHistoryItem) => {
+    if (!editorData) return;
+
+    try {
+      // Call restore API
+      const restored = await articleService.restoreVersion(editorData.articleId, version.versionNumber);
+
+      // Update editor state with restored content
+      setTitle(restored.title);
+
+      if (restored.contentFormat === 'tiptap-json') {
+        try {
+          const parsedContent = JSON.parse(restored.content);
+          setContent(parsedContent);
+          setContentFormat('tiptap-json');
+        } catch (error) {
+          setContent(restored.content);
+          setContentFormat('markdown');
+        }
+      } else {
+        setContent(restored.content);
+        setContentFormat('markdown');
+      }
+
+      // Clear preview state
+      setPreviewingVersion(null);
+      setHasChanges(false);
+      setCanUndo(false);
+
+      // Close version history panel
+      setShowVersionHistory(false);
+
+      alert('Version restored successfully!');
+    } catch (error: any) {
+      console.error('Failed to restore version:', error);
+      throw error;
+    }
+  }, [editorData]);
+
+  const handleBackToCurrent = useCallback(async () => {
+    if (!editorData) return;
+
+    try {
+      // Reload current article
+      const current = await articleService.getArticle(editorData.articleId);
+
+      setTitle(current.title);
+
+      if (current.contentFormat === 'tiptap-json') {
+        try {
+          const parsedContent = JSON.parse(current.content);
+          setContent(parsedContent);
+          setContentFormat('tiptap-json');
+        } catch (error) {
+          setContent(current.content);
+          setContentFormat('markdown');
+        }
+      } else {
+        setContent(current.content);
+        setContentFormat('markdown');
+      }
+
+      setPreviewingVersion(null);
+    } catch (error) {
+      console.error('Failed to load current version:', error);
+      alert('Failed to load current version');
+    }
+  }, [editorData]);
+
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 's') {
       e.preventDefault();
       handleSave();
     }
     if (e.key === 'Escape') {
-      handleCancel();
+      if (showVersionHistory) {
+        setShowVersionHistory(false);
+        setPreviewingVersion(null);
+      } else if (previewingVersion) {
+        handleBackToCurrent();
+      } else {
+        handleCancel();
+      }
     }
-  }, [handleSave, handleCancel]);
+    // Cmd/Ctrl + H for version history
+    if ((e.metaKey || e.ctrlKey) && e.key === 'h') {
+      e.preventDefault();
+      setShowVersionHistory(prev => {
+        // 패널을 닫을 때는 프리뷰도 함께 리셋
+        if (prev) {
+          setPreviewingVersion(null);
+        }
+        return !prev;
+      });
+    }
+  }, [handleSave, handleCancel, showVersionHistory, previewingVersion, handleBackToCurrent]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
@@ -325,59 +437,100 @@ const EditorApp: React.FC = () => {
 
   return (
     <div className={styles.editorContainer}>
-      <div className={styles.header}>
-        <div className={styles.headerContent}>
-          <div className={styles.titleSection}>
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className={styles.titleInput}
-              placeholder="Enter title"
-            />
+      {/* Version preview banner */}
+      {previewingVersion && (
+        <div className={styles.versionPreviewBanner}>
+          <div className={styles.versionPreviewText}>
+            Viewing version from {formatRelativeTime(previewingVersion.createdAt)}
           </div>
-          
-          <div className={styles.actionButtons}>
+          <div className={styles.versionPreviewActions}>
             <button
-              onClick={handleSave}
-              disabled={saving || !hasChanges}
-              className={`${styles.saveButton} ${hasChanges ? styles.hasChanges : ''}`}
-              title="Save (Ctrl+S)"
+              onClick={handleBackToCurrent}
+              className={styles.backToCurrentButton}
             >
-              <IoSave size={20} />
-              {saving ? 'Saving...' : t('common_save')}
-            </button>
-            
-            <button
-              onClick={handleCancel}
-              disabled={saving}
-              className={styles.cancelButton}
-              title="Cancel (Esc)"
-            >
-              <IoClose size={20} />
-              {t('common_cancel')}
+              Back to current
             </button>
           </div>
         </div>
+      )}
+
+      {/* Subtle action buttons in top-right corner */}
+      <div className={styles.actionBar}>
+        <div className={styles.statusIndicator}>
+          {saving ? (
+            <span className={styles.savingStatus}>Saving...</span>
+          ) : hasChanges ? (
+            <span className={styles.unsavedStatus}>Unsaved</span>
+          ) : (
+            <span className={styles.savedStatus}>Saved</span>
+          )}
+        </div>
+
+        <div className={styles.actionButtons}>
+          <button
+            onClick={() => setShowVersionHistory(true)}
+            className={styles.versionHistoryButton}
+            title="Version History (Cmd+H)"
+          >
+            <IoTimeOutline size={16} />
+          </button>
+
+          <button
+            onClick={handleSave}
+            disabled={saving || !hasChanges || !!previewingVersion}
+            className={styles.saveButton}
+            title="Save (Cmd+S)"
+          >
+            <IoSave size={16} />
+          </button>
+
+          <button
+            onClick={handleCancel}
+            disabled={saving}
+            className={styles.cancelButton}
+            title="Close (Esc)"
+          >
+            <IoClose size={16} />
+          </button>
+        </div>
       </div>
 
-      <div className={styles.editorSection}>
+      {/* Centered content area */}
+      <div className={styles.contentArea}>
+        {/* Large title input */}
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={styles.titleInput}
+          placeholder="Untitled"
+        />
+
+        {/* Editor with seamless integration */}
         <div className={styles.editorWrapper}>
           <EditorWrapper
             content={content}
             contentFormat={contentFormat}
             onChange={handleEditorChange}
-            placeholder="Enter content..."
-            readOnly={saving}
+            placeholder="Type something..."
+            readOnly={saving || !!previewingVersion}
             onHistoryStateChange={handleHistoryStateChange}
           />
         </div>
       </div>
 
-      {hasChanges && (
-        <div className={styles.changesIndicator}>
-          You have unsaved changes
-        </div>
+      {/* Version History Panel */}
+      {showVersionHistory && editorData && (
+        <VersionHistoryPanel
+          articleId={editorData.articleId}
+          currentVersionNumber={currentVersionNumber}
+          onClose={() => {
+            setShowVersionHistory(false);
+            setPreviewingVersion(null);
+          }}
+          onVersionSelect={handleVersionSelect}
+          onRestore={handleVersionRestore}
+        />
       )}
     </div>
   );

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -108,7 +108,18 @@ const EditorApp: React.FC = () => {
               timestamp: Date.now()
             }
           });
-          
+
+          // Load current version number
+          try {
+            const versions = await articleService.getArticleVersions(data.articleId);
+            if (versions.length > 0) {
+              setCurrentVersionNumber(versions[0].versionNumber);
+            }
+          } catch (error) {
+            console.warn('Failed to load current version number:', error);
+            // Continue without version number - non-critical
+          }
+
         } catch (error) {
           console.error('Failed to load editor data:', error);
           console.error('Session key:', sessionKey);
@@ -334,6 +345,16 @@ const EditorApp: React.FC = () => {
       } else {
         setContent(restored.content);
         setContentFormat('markdown');
+      }
+
+      // Update current version number after restore
+      try {
+        const versions = await articleService.getArticleVersions(editorData.articleId);
+        if (versions.length > 0) {
+          setCurrentVersionNumber(versions[0].versionNumber);
+        }
+      } catch (error) {
+        console.warn('Failed to update version number after restore:', error);
       }
 
       // Clear preview state

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -441,14 +441,14 @@ const EditorApp: React.FC = () => {
       {previewingVersion && (
         <div className={styles.versionPreviewBanner}>
           <div className={styles.versionPreviewText}>
-            Viewing version from {formatRelativeTime(previewingVersion.createdAt)}
+            {t('editor_viewingVersion')} {formatRelativeTime(previewingVersion.createdAt)}
           </div>
           <div className={styles.versionPreviewActions}>
             <button
               onClick={handleBackToCurrent}
               className={styles.backToCurrentButton}
             >
-              Back to current
+              {t('editor_backToCurrent')}
             </button>
           </div>
         </div>
@@ -458,11 +458,11 @@ const EditorApp: React.FC = () => {
       <div className={styles.actionBar}>
         <div className={styles.statusIndicator}>
           {saving ? (
-            <span className={styles.savingStatus}>Saving...</span>
+            <span className={styles.savingStatus}>{t('editor_saving')}</span>
           ) : hasChanges ? (
-            <span className={styles.unsavedStatus}>Unsaved</span>
+            <span className={styles.unsavedStatus}>{t('editor_unsaved')}</span>
           ) : (
-            <span className={styles.savedStatus}>Saved</span>
+            <span className={styles.savedStatus}>{t('editor_saved')}</span>
           )}
         </div>
 
@@ -470,7 +470,7 @@ const EditorApp: React.FC = () => {
           <button
             onClick={() => setShowVersionHistory(true)}
             className={styles.versionHistoryButton}
-            title="Version History (Cmd+H)"
+            title={t('editor_versionHistoryTooltip')}
           >
             <IoTimeOutline size={16} />
           </button>
@@ -479,7 +479,7 @@ const EditorApp: React.FC = () => {
             onClick={handleSave}
             disabled={saving || !hasChanges || !!previewingVersion}
             className={styles.saveButton}
-            title="Save (Cmd+S)"
+            title={t('editor_saveTooltip')}
           >
             <IoSave size={16} />
           </button>
@@ -488,7 +488,7 @@ const EditorApp: React.FC = () => {
             onClick={handleCancel}
             disabled={saving}
             className={styles.cancelButton}
-            title="Close (Esc)"
+            title={t('editor_closeTooltip')}
           >
             <IoClose size={16} />
           </button>

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -3,6 +3,7 @@ import { browser } from 'wxt/browser';
 import { articleService, UpdateArticleDto, VersionHistoryItem } from '../../services/articleService';
 import EditorWrapper from '../sidepanel/Editor/Editor';
 import VersionHistoryPanel from './VersionHistoryPanel';
+import RestoreToast from './RestoreToast';
 import { IoSave, IoClose, IoArrowBack, IoTimeOutline } from 'react-icons/io5';
 import { trackPageViewBridge, trackPageExitBridge, trackArchiveEditStartedBridge, trackArchiveEditSavedBridge, trackArchiveEditCancelledBridge, trackArchiveFullscreenEditorOpenedBridge } from '../../analytics/bridge';
 import { useI18n } from '../../hooks/useI18n';
@@ -38,6 +39,11 @@ const EditorApp: React.FC = () => {
   const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [previewingVersion, setPreviewingVersion] = useState<VersionHistoryItem | null>(null);
   const [currentVersionNumber, setCurrentVersionNumber] = useState<number | undefined>(undefined);
+
+  // Toast state
+  const [showRestoreToast, setShowRestoreToast] = useState(false);
+  const [restoredVersionInfo, setRestoredVersionInfo] = useState<{ versionNumber: number; timestamp: string } | null>(null);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
 
   // 언어 설정 초기화 및 실시간 변경 감지
   useEffect(() => {
@@ -385,9 +391,16 @@ const EditorApp: React.FC = () => {
       // Close version history panel
       setShowVersionHistory(false);
 
-      alert('Version restored successfully!');
+      // Show success toast
+      setRestoredVersionInfo({
+        versionNumber: version.versionNumber,
+        timestamp: formatRelativeTime(version.createdAt),
+      });
+      setShowRestoreToast(true);
     } catch (error: any) {
       console.error('Failed to restore version:', error);
+      // Show error message
+      setRestoreError(error.message || 'Unknown error');
       throw error;
     }
   }, [editorData, applyArticleContent]);
@@ -407,6 +420,15 @@ const EditorApp: React.FC = () => {
       alert('Failed to load current version');
     }
   }, [editorData, applyArticleContent]);
+
+  const handleToastClose = useCallback(() => {
+    setShowRestoreToast(false);
+    setRestoredVersionInfo(null);
+  }, []);
+
+  const handleErrorClose = useCallback(() => {
+    setRestoreError(null);
+  }, []);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 's') {
@@ -464,6 +486,18 @@ const EditorApp: React.FC = () => {
 
   return (
     <div className={styles.editorContainer}>
+      {/* Error banner */}
+      {restoreError && (
+        <div className={styles.errorBanner}>
+          <div className={styles.errorText}>
+            Failed to restore version: {restoreError}
+          </div>
+          <button onClick={handleErrorClose} className={styles.errorCloseButton}>
+            ×
+          </button>
+        </div>
+      )}
+
       {/* Version preview banner */}
       {previewingVersion && (
         <div className={styles.versionPreviewBanner}>
@@ -557,6 +591,15 @@ const EditorApp: React.FC = () => {
           }}
           onVersionSelect={handleVersionSelect}
           onRestore={handleVersionRestore}
+        />
+      )}
+
+      {/* Restore Success Toast */}
+      {showRestoreToast && restoredVersionInfo && (
+        <RestoreToast
+          versionNumber={restoredVersionInfo.versionNumber}
+          timestamp={restoredVersionInfo.timestamp}
+          onClose={handleToastClose}
         />
       )}
     </div>

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -39,9 +39,25 @@ const EditorApp: React.FC = () => {
   const [previewingVersion, setPreviewingVersion] = useState<VersionHistoryItem | null>(null);
   const [currentVersionNumber, setCurrentVersionNumber] = useState<number | undefined>(undefined);
 
-  // 언어 설정 초기화
+  // 언어 설정 초기화 및 실시간 변경 감지
   useEffect(() => {
     initializeLanguage();
+
+    // Storage 변경 감지 - 사이드 패널에서 언어가 변경되면 즉시 반영
+    const handleStorageChange = (
+      changes: { [key: string]: browser.Storage.StorageChange },
+      areaName: string
+    ) => {
+      if (areaName === 'sync' && changes['tyquill-language-preference']) {
+        initializeLanguage();
+      }
+    };
+
+    browser.storage.onChanged.addListener(handleStorageChange);
+
+    return () => {
+      browser.storage.onChanged.removeListener(handleStorageChange);
+    };
   }, [initializeLanguage]);
 
   // browser.storage.local에서 데이터 읽기 및 편집기 상태 설정

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -300,28 +300,34 @@ const EditorApp: React.FC = () => {
     window.close();
   }, [hasChanges, editorData, title, content]);
 
+  // Helper function to apply article content with proper parsing
+  const applyArticleContent = useCallback((
+    content: string,
+    format: 'markdown' | 'tiptap-json'
+  ) => {
+    if (format === 'tiptap-json') {
+      try {
+        const parsedContent = JSON.parse(content);
+        setContent(parsedContent);
+        setContentFormat('tiptap-json');
+      } catch (error) {
+        console.warn('Failed to parse TipTap JSON, falling back to markdown:', error);
+        setContent(content);
+        setContentFormat('markdown');
+      }
+    } else {
+      setContent(content);
+      setContentFormat('markdown');
+    }
+  }, []);
+
   // Version history handlers
   const handleVersionSelect = useCallback((version: VersionHistoryItem) => {
     // Preview the selected version
     setPreviewingVersion(version);
     setTitle(version.title);
-
-    // Parse content based on format
-    if (version.contentFormat === 'tiptap-json') {
-      try {
-        const parsedContent = JSON.parse(version.content);
-        setContent(parsedContent);
-        setContentFormat('tiptap-json');
-      } catch (error) {
-        console.warn('Failed to parse TipTap JSON, using as markdown:', error);
-        setContent(version.content);
-        setContentFormat('markdown');
-      }
-    } else {
-      setContent(version.content);
-      setContentFormat('markdown');
-    }
-  }, []);
+    applyArticleContent(version.content, version.contentFormat);
+  }, [applyArticleContent]);
 
   const handleVersionRestore = useCallback(async (version: VersionHistoryItem) => {
     if (!editorData) return;
@@ -332,20 +338,7 @@ const EditorApp: React.FC = () => {
 
       // Update editor state with restored content
       setTitle(restored.title);
-
-      if (restored.contentFormat === 'tiptap-json') {
-        try {
-          const parsedContent = JSON.parse(restored.content);
-          setContent(parsedContent);
-          setContentFormat('tiptap-json');
-        } catch (error) {
-          setContent(restored.content);
-          setContentFormat('markdown');
-        }
-      } else {
-        setContent(restored.content);
-        setContentFormat('markdown');
-      }
+      applyArticleContent(restored.content, restored.contentFormat || 'markdown');
 
       // Update current version number after restore
       try {
@@ -370,7 +363,7 @@ const EditorApp: React.FC = () => {
       console.error('Failed to restore version:', error);
       throw error;
     }
-  }, [editorData]);
+  }, [editorData, applyArticleContent]);
 
   const handleBackToCurrent = useCallback(async () => {
     if (!editorData) return;
@@ -380,27 +373,13 @@ const EditorApp: React.FC = () => {
       const current = await articleService.getArticle(editorData.articleId);
 
       setTitle(current.title);
-
-      if (current.contentFormat === 'tiptap-json') {
-        try {
-          const parsedContent = JSON.parse(current.content);
-          setContent(parsedContent);
-          setContentFormat('tiptap-json');
-        } catch (error) {
-          setContent(current.content);
-          setContentFormat('markdown');
-        }
-      } else {
-        setContent(current.content);
-        setContentFormat('markdown');
-      }
-
+      applyArticleContent(current.content, current.contentFormat || 'markdown');
       setPreviewingVersion(null);
     } catch (error) {
       console.error('Failed to load current version:', error);
       alert('Failed to load current version');
     }
-  }, [editorData]);
+  }, [editorData, applyArticleContent]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 's') {

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -270,6 +270,17 @@ const EditorApp: React.FC = () => {
         session_duration: Math.round((Date.now() - pageStartTimeRef.current) / 1000)
       }).catch(() => {});
 
+      // Update current version number after save
+      try {
+        const versions = await articleService.getArticleVersions(editorData.articleId);
+        if (versions.length > 0) {
+          setCurrentVersionNumber(versions[0].versionNumber);
+        }
+      } catch (error) {
+        console.warn('Failed to update version number after save:', error);
+        // Continue - non-critical
+      }
+
       // 저장 성공 시 변경사항 플래그 및 실행 취소 상태 초기화
       setHasChanges(false);
       setCanUndo(false);

--- a/src/components/editor/RestoreToast.module.css
+++ b/src/components/editor/RestoreToast.module.css
@@ -56,7 +56,7 @@
   /* Extra large border-radius for pill-like shape */
   border-radius: 28px;
 
-  /* Multi-layered shadows for depth with specular highlights - GREEN THEME */
+  /* Multi-layered shadows for depth with specular highlights */
   box-shadow:
     /* Soft outer glow */
     0 20px 60px rgba(0, 0, 0, 0.15),
@@ -65,9 +65,9 @@
     /* Specular highlights - top left (cool light) */
     inset 10px 10px 20px rgba(255, 255, 255, 0.2),
     inset 2px 2px 5px rgba(255, 255, 255, 0.3),
-    /* Specular highlights - bottom right (green light) */
-    inset -10px -10px 20px rgba(76, 175, 80, 0.05),
-    inset -2px -2px 30px rgba(76, 175, 80, 0.08),
+    /* Specular highlights - bottom right (subtle) */
+    inset -10px -10px 20px rgba(0, 0, 0, 0.02),
+    inset -2px -2px 30px rgba(0, 0, 0, 0.03),
     /* Refined edge definition */
     0 0 0 1px rgba(0, 0, 0, 0.06);
 
@@ -93,15 +93,15 @@
     0 10px 28px rgba(0, 0, 0, 0.14),
     inset 10px 10px 20px rgba(255, 255, 255, 0.25),
     inset 2px 2px 5px rgba(255, 255, 255, 0.35),
-    inset -10px -10px 20px rgba(76, 175, 80, 0.08),
-    inset -2px -2px 30px rgba(76, 175, 80, 0.1),
+    inset -10px -10px 20px rgba(0, 0, 0, 0.03),
+    inset -2px -2px 30px rgba(0, 0, 0, 0.04),
     0 0 0 1px rgba(0, 0, 0, 0.08);
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.6);
 }
 
 /* ===================================
-   ICON - SUCCESS GRADIENT (GREEN)
+   ICON - MONOCHROME GRADIENT
    =================================== */
 
 .iconContainer {
@@ -113,15 +113,15 @@
   height: 40px;
   border-radius: 50%;
 
-  /* Success color gradient - Green tones */
-  background: linear-gradient(135deg, #4CAF50 0%, #66BB6A 50%, #81C784 100%);
+  /* Monochrome gradient - Black/White */
+  background: linear-gradient(135deg, #2a2a2a 0%, #4a4a4a 50%, #6a6a6a 100%);
 
   /* Multi-layered glow for depth */
   box-shadow:
-    /* Vibrant colored glow */
-    0 4px 20px rgba(76, 175, 80, 0.4),
+    /* Subtle shadow */
+    0 4px 20px rgba(0, 0, 0, 0.2),
     /* Soft outer glow */
-    0 2px 10px rgba(76, 175, 80, 0.3),
+    0 2px 10px rgba(0, 0, 0, 0.15),
     /* Inner highlight for 3D effect */
     inset 0 1px 0 rgba(255, 255, 255, 0.4);
 

--- a/src/components/editor/RestoreToast.module.css
+++ b/src/components/editor/RestoreToast.module.css
@@ -1,0 +1,275 @@
+/* ===================================
+   LIQUID GLASS TOAST - SUCCESS STYLE
+   =================================== */
+
+.toastContainer {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 2147483647; /* Maximum z-index to ensure visibility over all page content */
+  width: 400px;
+  max-width: calc(100vw - 40px);
+
+  /* Entrance animation: fade + slide from right */
+  opacity: 0;
+  transform: translateX(100px) scale(0.95);
+  transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1); /* Elastic ease-out for premium feel */
+  pointer-events: none;
+}
+
+.toastContainer.visible {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  pointer-events: auto;
+}
+
+.toastContainer.leaving {
+  opacity: 0;
+  transform: translateX(100px) scale(0.95);
+  transition: all 0.3s cubic-bezier(0.4, 0, 1, 1); /* Faster exit */
+  pointer-events: none;
+}
+
+.confettiWrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 140px;
+  overflow: visible;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ===================================
+   LIQUID GLASS EFFECT
+   =================================== */
+
+.toast {
+  /* Translucent white background for liquid glass effect */
+  background: rgba(255, 255, 255, 0.75);
+
+  /* Liquid glass blur effect with enhanced color filters */
+  backdrop-filter: blur(20px) contrast(80%) saturate(120%);
+  -webkit-backdrop-filter: blur(20px) contrast(80%) saturate(120%);
+
+  /* Extra large border-radius for pill-like shape */
+  border-radius: 28px;
+
+  /* Multi-layered shadows for depth with specular highlights - GREEN THEME */
+  box-shadow:
+    /* Soft outer glow */
+    0 20px 60px rgba(0, 0, 0, 0.15),
+    /* Medium shadow for elevation */
+    0 8px 24px rgba(0, 0, 0, 0.12),
+    /* Specular highlights - top left (cool light) */
+    inset 10px 10px 20px rgba(255, 255, 255, 0.2),
+    inset 2px 2px 5px rgba(255, 255, 255, 0.3),
+    /* Specular highlights - bottom right (green light) */
+    inset -10px -10px 20px rgba(76, 175, 80, 0.05),
+    inset -2px -2px 30px rgba(76, 175, 80, 0.08),
+    /* Refined edge definition */
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+
+  /* Layout */
+  display: flex;
+  align-items: flex-start;
+  padding: 20px;
+  gap: 14px;
+  position: relative;
+  z-index: 1;
+
+  /* Subtle gradient border for liquid glass effect */
+  border: 1px solid rgba(255, 255, 255, 0.5);
+
+  /* Smooth transform transitions */
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover state - subtle lift effect */
+.toast:hover {
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.18),
+    0 10px 28px rgba(0, 0, 0, 0.14),
+    inset 10px 10px 20px rgba(255, 255, 255, 0.25),
+    inset 2px 2px 5px rgba(255, 255, 255, 0.35),
+    inset -10px -10px 20px rgba(76, 175, 80, 0.08),
+    inset -2px -2px 30px rgba(76, 175, 80, 0.1),
+    0 0 0 1px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+/* ===================================
+   ICON - SUCCESS GRADIENT (GREEN)
+   =================================== */
+
+.iconContainer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+
+  /* Success color gradient - Green tones */
+  background: linear-gradient(135deg, #4CAF50 0%, #66BB6A 50%, #81C784 100%);
+
+  /* Multi-layered glow for depth */
+  box-shadow:
+    /* Vibrant colored glow */
+    0 4px 20px rgba(76, 175, 80, 0.4),
+    /* Soft outer glow */
+    0 2px 10px rgba(76, 175, 80, 0.3),
+    /* Inner highlight for 3D effect */
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+
+  /* Subtle animation on appearance */
+  animation: iconPulse 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes iconPulse {
+  0% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.icon {
+  color: white;
+  font-size: 24px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
+}
+
+/* ===================================
+   CONTENT - HIGH CONTRAST TEXT
+   =================================== */
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0; /* Allow text truncation */
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1a1a1a;
+  line-height: 1.3;
+  letter-spacing: -0.02em; /* Tighter tracking for Apple feel */
+
+  /* Subtle text shadow for depth */
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
+}
+
+.version {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(26, 26, 26, 0.75);
+  line-height: 1.4;
+
+  /* Subtle glow for readability */
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.3);
+}
+
+.timestamp {
+  font-size: 12px;
+  color: rgba(26, 26, 26, 0.5);
+  line-height: 1.4;
+  margin-top: 2px;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
+  letter-spacing: -0.01em;
+}
+
+/* ===================================
+   RESPONSIVE DESIGN - MOBILE
+   =================================== */
+
+@media (max-width: 480px) {
+  .toastContainer {
+    top: 16px;
+    right: 16px;
+    width: calc(100vw - 32px);
+  }
+
+  .toast {
+    padding: 16px;
+    gap: 12px;
+    border-radius: 18px;
+  }
+
+  .iconContainer {
+    width: 36px;
+    height: 36px;
+  }
+
+  .icon {
+    font-size: 20px;
+  }
+
+  .title {
+    font-size: 15px;
+  }
+
+  .version {
+    font-size: 13px;
+  }
+
+  .timestamp {
+    font-size: 11px;
+  }
+}
+
+/* ===================================
+   ACCESSIBILITY & REDUCED MOTION
+   =================================== */
+
+/* Respect user's motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .toastContainer {
+    transition: opacity 0.2s ease;
+  }
+
+  .toastContainer.visible {
+    transform: none;
+  }
+
+  .toastContainer.leaving {
+    transform: none;
+  }
+
+  .iconContainer {
+    animation: none;
+  }
+
+  .toast:hover {
+    transform: none;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .toast {
+    background: rgba(255, 255, 255, 0.95);
+    border: 2px solid rgba(0, 0, 0, 0.3);
+  }
+
+  .title,
+  .version {
+    color: #000000;
+  }
+
+  .timestamp {
+    color: rgba(0, 0, 0, 0.7);
+  }
+}

--- a/src/components/editor/RestoreToast.tsx
+++ b/src/components/editor/RestoreToast.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+import styles from './RestoreToast.module.css';
+import Confetti from '../sidepanel/Confetti/Confetti';
+import { useI18n } from '../../hooks/useI18n';
+
+interface RestoreToastProps {
+  versionNumber: number;
+  timestamp: string;
+  onClose: () => void;
+  duration?: number;
+}
+
+const RestoreToast: React.FC<RestoreToastProps> = ({
+  versionNumber,
+  timestamp,
+  onClose,
+  duration = 4000,
+}) => {
+  const { t } = useI18n();
+  const [isVisible, setIsVisible] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(true);
+
+  useEffect(() => {
+    // 컴포넌트 마운트 후 애니메이션 시작
+    const timer = setTimeout(() => setIsVisible(true), 10);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    // Confetti는 2초 후 숨김
+    const confettiTimer = setTimeout(() => {
+      setShowConfetti(false);
+    }, 2000);
+
+    // Toast는 duration 후 닫힘
+    if (duration > 0) {
+      const timer = setTimeout(() => {
+        handleClose();
+      }, duration);
+      return () => {
+        clearTimeout(timer);
+        clearTimeout(confettiTimer);
+      };
+    }
+
+    return () => clearTimeout(confettiTimer);
+  }, [duration]);
+
+  const handleClose = () => {
+    setIsLeaving(true);
+    setTimeout(() => {
+      onClose();
+    }, 300); // 애니메이션 시간과 맞춤
+  };
+
+  return (
+    <div
+      className={`${styles.toastContainer} ${isVisible ? styles.visible : ''} ${isLeaving ? styles.leaving : ''}`}
+    >
+      {/* Confetti Effect */}
+      {showConfetti && (
+        <div className={styles.confettiWrapper}>
+          <Confetti
+            particleCount={60}
+            durationMs={2000}
+            colors={['#4CAF50', '#81C784', '#A5D6A7', '#C8E6C9', '#E8F5E9']}
+          />
+        </div>
+      )}
+
+      {/* Toast Content */}
+      <div className={styles.toast}>
+        <div className={styles.iconContainer}>
+          <IoCheckmarkCircle className={styles.icon} />
+        </div>
+        <div className={styles.content}>
+          <div className={styles.title}>{t('editor_restoreCompleted')}</div>
+          <div className={styles.version}>
+            {t('editor_restoredToVersion').replace('{versionNumber}', String(versionNumber))}
+          </div>
+          <div className={styles.timestamp}>{timestamp}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RestoreToast;

--- a/src/components/editor/RestoreToast.tsx
+++ b/src/components/editor/RestoreToast.tsx
@@ -65,7 +65,7 @@ const RestoreToast: React.FC<RestoreToastProps> = ({
           <Confetti
             particleCount={60}
             durationMs={2000}
-            colors={['#4CAF50', '#81C784', '#A5D6A7', '#C8E6C9', '#E8F5E9']}
+            colors={['#000000', '#333333', '#666666', '#999999', '#CCCCCC']}
           />
         </div>
       )}

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -4,7 +4,6 @@ import { articleService, VersionHistoryItem } from '../../services/articleServic
 import { formatRelativeTime, getCharacterCount } from '../../utils/timeFormat';
 import { useI18n } from '../../hooks/useI18n';
 import styles from './EditorApp.module.css';
-import RestoreToast from './RestoreToast';
 
 interface VersionHistoryPanelProps {
     articleId: number;
@@ -29,8 +28,6 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
     const [restoring, setRestoring] = useState(false);
     const [showConfirmModal, setShowConfirmModal] = useState(false);
     const [versionToRestore, setVersionToRestore] = useState<VersionHistoryItem | null>(null);
-    const [showRestoreToast, setShowRestoreToast] = useState(false);
-    const [restoredVersionInfo, setRestoredVersionInfo] = useState<{ versionNumber: number; timestamp: string } | null>(null);
 
     // Load versions on mount
     useEffect(() => {
@@ -101,19 +98,12 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
             setRestoring(true);
             await onRestore(versionToRestore);
 
-            // Store version info for toast
-            setRestoredVersionInfo({
-                versionNumber: versionToRestore.versionNumber,
-                timestamp: formatRelativeTime(versionToRestore.createdAt),
-            });
-
-            // Close modal and show success toast
+            // Close modal (success will be handled by parent)
             setShowConfirmModal(false);
             setVersionToRestore(null);
-            setShowRestoreToast(true);
         } catch (err: any) {
+            // Error will be handled by parent component
             console.error('Failed to restore version:', err);
-            alert(`Failed to restore version: ${err.message || 'Unknown error'}`);
         } finally {
             setRestoring(false);
         }
@@ -126,12 +116,6 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
             setVersionToRestore(null);
         }
     }, [restoring]);
-
-    // Handle toast close
-    const handleToastClose = useCallback(() => {
-        setShowRestoreToast(false);
-        setRestoredVersionInfo(null);
-    }, []);
 
     return (
         <>
@@ -271,15 +255,6 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                         </div>
                     </div>
                 </div>
-            )}
-
-            {/* Success Toast */}
-            {showRestoreToast && restoredVersionInfo && (
-                <RestoreToast
-                    versionNumber={restoredVersionInfo.versionNumber}
-                    timestamp={restoredVersionInfo.timestamp}
-                    onClose={handleToastClose}
-                />
             )}
         </>
     );

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -4,6 +4,7 @@ import { articleService, VersionHistoryItem } from '../../services/articleServic
 import { formatRelativeTime, getCharacterCount } from '../../utils/timeFormat';
 import { useI18n } from '../../hooks/useI18n';
 import styles from './EditorApp.module.css';
+import RestoreToast from './RestoreToast';
 
 interface VersionHistoryPanelProps {
     articleId: number;
@@ -28,6 +29,8 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
     const [restoring, setRestoring] = useState(false);
     const [showConfirmModal, setShowConfirmModal] = useState(false);
     const [versionToRestore, setVersionToRestore] = useState<VersionHistoryItem | null>(null);
+    const [showRestoreToast, setShowRestoreToast] = useState(false);
+    const [restoredVersionInfo, setRestoredVersionInfo] = useState<{ versionNumber: number; timestamp: string } | null>(null);
 
     // Load versions on mount
     useEffect(() => {
@@ -97,8 +100,17 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
         try {
             setRestoring(true);
             await onRestore(versionToRestore);
+
+            // Store version info for toast
+            setRestoredVersionInfo({
+                versionNumber: versionToRestore.versionNumber,
+                timestamp: formatRelativeTime(versionToRestore.createdAt),
+            });
+
+            // Close modal and show success toast
             setShowConfirmModal(false);
             setVersionToRestore(null);
+            setShowRestoreToast(true);
         } catch (err: any) {
             console.error('Failed to restore version:', err);
             alert(`Failed to restore version: ${err.message || 'Unknown error'}`);
@@ -114,6 +126,12 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
             setVersionToRestore(null);
         }
     }, [restoring]);
+
+    // Handle toast close
+    const handleToastClose = useCallback(() => {
+        setShowRestoreToast(false);
+        setRestoredVersionInfo(null);
+    }, []);
 
     return (
         <>
@@ -253,6 +271,15 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                         </div>
                     </div>
                 </div>
+            )}
+
+            {/* Success Toast */}
+            {showRestoreToast && restoredVersionInfo && (
+                <RestoreToast
+                    versionNumber={restoredVersionInfo.versionNumber}
+                    timestamp={restoredVersionInfo.timestamp}
+                    onClose={handleToastClose}
+                />
             )}
         </>
     );

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { IoClose, IoCheckmarkCircle } from 'react-icons/io5';
+import { articleService, VersionHistoryItem } from '../../services/articleService';
+import { formatRelativeTime, getCharacterCount } from '../../utils/timeFormat';
+import styles from './EditorApp.module.css';
+
+interface VersionHistoryPanelProps {
+    articleId: number;
+    currentVersionNumber?: number;
+    onClose: () => void;
+    onVersionSelect: (version: VersionHistoryItem) => void;
+    onRestore: (version: VersionHistoryItem) => Promise<void>;
+}
+
+const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
+    articleId,
+    currentVersionNumber,
+    onClose,
+    onVersionSelect,
+    onRestore,
+}) => {
+    const [versions, setVersions] = useState<VersionHistoryItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedVersionNumber, setSelectedVersionNumber] = useState<number | null>(null);
+    const [restoring, setRestoring] = useState(false);
+
+    // Load versions on mount
+    useEffect(() => {
+        const loadVersions = async () => {
+            try {
+                setLoading(true);
+                setError(null);
+                const data = await articleService.getArticleVersions(articleId);
+
+                // Sort by version number descending (newest first)
+                const sortedVersions = data.sort((a, b) => b.versionNumber - a.versionNumber);
+
+                // Calculate character counts
+                const versionsWithCounts = sortedVersions.map(v => ({
+                    ...v,
+                    characterCount: getCharacterCount(v.content)
+                }));
+
+                setVersions(versionsWithCounts);
+            } catch (err: any) {
+                console.error('Failed to load versions:', err);
+                setError(err.message || 'Failed to load version history');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadVersions();
+    }, [articleId]);
+
+    // Handle version selection
+    const handleVersionClick = useCallback((version: VersionHistoryItem) => {
+        setSelectedVersionNumber(version.versionNumber);
+        onVersionSelect(version);
+    }, [onVersionSelect]);
+
+    // Handle restore
+    const handleRestore = useCallback(async (version: VersionHistoryItem) => {
+        if (restoring) return;
+
+        const confirmRestore = window.confirm(
+            `Are you sure you want to restore this version from ${formatRelativeTime(version.createdAt)}?\n\nThis will create a new version with this content.`
+        );
+
+        if (!confirmRestore) return;
+
+        try {
+            setRestoring(true);
+            await onRestore(version);
+        } catch (err: any) {
+            console.error('Failed to restore version:', err);
+            alert(`Failed to restore version: ${err.message || 'Unknown error'}`);
+        } finally {
+            setRestoring(false);
+        }
+    }, [onRestore, restoring]);
+
+    return (
+        <>
+            {/* Backdrop */}
+            <div className={styles.versionHistoryBackdrop} onClick={onClose} />
+
+            {/* Panel */}
+            <div className={styles.versionHistoryPanel}>
+                {/* Header */}
+                <div className={styles.versionHistoryHeader}>
+                    <h2 className={styles.versionHistoryTitle}>Version History</h2>
+                    <button
+                        onClick={onClose}
+                        className={styles.versionHistoryCloseButton}
+                        title="Close (Esc)"
+                    >
+                        <IoClose size={20} />
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div className={styles.versionHistoryContent}>
+                    {loading && (
+                        <div className={styles.versionHistoryLoading}>
+                            Loading versions...
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className={styles.versionHistoryError}>
+                            {error}
+                        </div>
+                    )}
+
+                    {!loading && !error && versions.length === 0 && (
+                        <div className={styles.versionHistoryEmpty}>
+                            No version history available
+                        </div>
+                    )}
+
+                    {!loading && !error && versions.length > 0 && (
+                        <div className={styles.versionList}>
+                            {versions.map((version) => {
+                                const isSelected = selectedVersionNumber === version.versionNumber;
+                                const isCurrent = currentVersionNumber === version.versionNumber;
+
+                                return (
+                                    <div
+                                        key={version.versionNumber}
+                                        className={`${styles.versionItem} ${isSelected ? styles.versionItemSelected : ''} ${isCurrent ? styles.versionItemCurrent : ''}`}
+                                        onClick={() => handleVersionClick(version)}
+                                    >
+                                        <div className={styles.versionItemHeader}>
+                                            <div className={styles.versionNumber}>
+                                                {isCurrent && (
+                                                    <IoCheckmarkCircle
+                                                        size={14}
+                                                        className={styles.versionCurrentIcon}
+                                                    />
+                                                )}
+                                                v{version.versionNumber}
+                                            </div>
+                                            <div className={styles.versionTime}>
+                                                {formatRelativeTime(version.createdAt)}
+                                            </div>
+                                        </div>
+
+                                        <div className={styles.versionItemBody}>
+                                            <div className={styles.versionTitle}>
+                                                {version.title || 'Untitled'}
+                                            </div>
+                                            <div className={styles.versionMeta}>
+                                                {version.characterCount?.toLocaleString()} characters
+                                            </div>
+                                        </div>
+
+                                        {isSelected && !isCurrent && (
+                                            <button
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleRestore(version);
+                                                }}
+                                                disabled={restoring}
+                                                className={styles.versionRestoreButton}
+                                            >
+                                                {restoring ? 'Restoring...' : 'Restore this version'}
+                                            </button>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default VersionHistoryPanel;

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { IoClose, IoCheckmarkCircle } from 'react-icons/io5';
 import { articleService, VersionHistoryItem } from '../../services/articleService';
 import { formatRelativeTime, getCharacterCount } from '../../utils/timeFormat';
+import { useI18n } from '../../hooks/useI18n';
 import styles from './EditorApp.module.css';
 
 interface VersionHistoryPanelProps {
@@ -19,6 +20,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
     onVersionSelect,
     onRestore,
 }) => {
+    const { t } = useI18n();
     const [versions, setVersions] = useState<VersionHistoryItem[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -109,11 +111,11 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
             <div className={styles.versionHistoryPanel}>
                 {/* Header */}
                 <div className={styles.versionHistoryHeader}>
-                    <h2 className={styles.versionHistoryTitle}>Version History</h2>
+                    <h2 className={styles.versionHistoryTitle}>{t('editor_versionHistoryTitle')}</h2>
                     <button
                         onClick={onClose}
                         className={styles.versionHistoryCloseButton}
-                        title="Close (Esc)"
+                        title={t('editor_closeEsc')}
                     >
                         <IoClose size={20} />
                     </button>
@@ -123,7 +125,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                 <div className={styles.versionHistoryContent}>
                     {loading && (
                         <div className={styles.versionHistoryLoading}>
-                            Loading versions...
+                            {t('editor_loadingVersions')}
                         </div>
                     )}
 
@@ -135,7 +137,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
 
                     {!loading && !error && versions.length === 0 && (
                         <div className={styles.versionHistoryEmpty}>
-                            No version history available
+                            {t('editor_noVersions')}
                         </div>
                     )}
 
@@ -171,7 +173,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                                                 {version.title || 'Untitled'}
                                             </div>
                                             <div className={styles.versionMeta}>
-                                                {version.characterCount?.toLocaleString()} characters
+                                                {version.characterCount?.toLocaleString()}{t('editor_characters')}
                                             </div>
                                         </div>
 
@@ -184,7 +186,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                                                 disabled={restoring}
                                                 className={styles.versionRestoreButton}
                                             >
-                                                {restoring ? 'Restoring...' : 'Restore this version'}
+                                                {restoring ? t('editor_restoring') : t('editor_restoreVersion')}
                                             </button>
                                         )}
                                     </div>

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -37,10 +37,29 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                 const sortedVersions = data.sort((a, b) => b.versionNumber - a.versionNumber);
 
                 // Calculate character counts
-                const versionsWithCounts = sortedVersions.map(v => ({
-                    ...v,
-                    characterCount: getCharacterCount(v.content)
-                }));
+                const versionsWithCounts = sortedVersions.map(v => {
+                    let characterCount: number;
+
+                    if (v.contentFormat === 'tiptap-json') {
+                        try {
+                            // Parse TipTap JSON and extract text
+                            const parsedContent = JSON.parse(v.content);
+                            characterCount = getCharacterCount(parsedContent);
+                        } catch (error) {
+                            // If parsing fails, treat as plain text
+                            console.warn('Failed to parse TipTap JSON for character count:', error);
+                            characterCount = getCharacterCount(v.content);
+                        }
+                    } else {
+                        // Markdown or plain text
+                        characterCount = getCharacterCount(v.content);
+                    }
+
+                    return {
+                        ...v,
+                        characterCount
+                    };
+                });
 
                 setVersions(versionsWithCounts);
             } catch (err: any) {

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -26,6 +26,8 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
     const [error, setError] = useState<string | null>(null);
     const [selectedVersionNumber, setSelectedVersionNumber] = useState<number | null>(null);
     const [restoring, setRestoring] = useState(false);
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
+    const [versionToRestore, setVersionToRestore] = useState<VersionHistoryItem | null>(null);
 
     // Load versions on mount
     useEffect(() => {
@@ -81,26 +83,37 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
         onVersionSelect(version);
     }, [onVersionSelect]);
 
-    // Handle restore
-    const handleRestore = useCallback(async (version: VersionHistoryItem) => {
+    // Handle restore button click - show modal
+    const handleRestoreClick = useCallback((version: VersionHistoryItem) => {
         if (restoring) return;
+        setVersionToRestore(version);
+        setShowConfirmModal(true);
+    }, [restoring]);
 
-        const confirmRestore = window.confirm(
-            `Are you sure you want to restore this version from ${formatRelativeTime(version.createdAt)}?\n\nThis will create a new version with this content.`
-        );
-
-        if (!confirmRestore) return;
+    // Handle confirmed restore
+    const handleConfirmRestore = useCallback(async () => {
+        if (!versionToRestore || restoring) return;
 
         try {
             setRestoring(true);
-            await onRestore(version);
+            await onRestore(versionToRestore);
+            setShowConfirmModal(false);
+            setVersionToRestore(null);
         } catch (err: any) {
             console.error('Failed to restore version:', err);
             alert(`Failed to restore version: ${err.message || 'Unknown error'}`);
         } finally {
             setRestoring(false);
         }
-    }, [onRestore, restoring]);
+    }, [versionToRestore, restoring, onRestore]);
+
+    // Handle modal close
+    const handleCloseModal = useCallback(() => {
+        if (!restoring) {
+            setShowConfirmModal(false);
+            setVersionToRestore(null);
+        }
+    }, [restoring]);
 
     return (
         <>
@@ -181,7 +194,7 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                                             <button
                                                 onClick={(e) => {
                                                     e.stopPropagation();
-                                                    handleRestore(version);
+                                                    handleRestoreClick(version);
                                                 }}
                                                 disabled={restoring}
                                                 className={styles.versionRestoreButton}
@@ -196,6 +209,51 @@ const VersionHistoryPanel: React.FC<VersionHistoryPanelProps> = ({
                     )}
                 </div>
             </div>
+
+            {/* Confirm Modal */}
+            {showConfirmModal && versionToRestore && (
+                <div className={styles.confirmModalOverlay} onClick={handleCloseModal}>
+                    <div className={styles.confirmModalContent} onClick={(e) => e.stopPropagation()}>
+                        <div className={styles.confirmModalHeader}>
+                            <h3 className={styles.confirmModalTitle}>
+                                {t('editor_restoreVersion')}
+                            </h3>
+                            <button
+                                onClick={handleCloseModal}
+                                disabled={restoring}
+                                className={styles.confirmModalCloseButton}
+                                aria-label={t('common_close')}
+                            >
+                                <IoClose size={20} />
+                            </button>
+                        </div>
+                        <div className={styles.confirmModalBody}>
+                            <p className={styles.confirmModalMessage}>
+                                {formatRelativeTime(versionToRestore.createdAt)} 버전을 복원하시겠습니까?
+                            </p>
+                            <p className={styles.confirmModalInfo}>
+                                새 버전이 생성되며, 현재 내용은 버전 히스토리에 저장됩니다.
+                            </p>
+                        </div>
+                        <div className={styles.confirmModalFooter}>
+                            <button
+                                onClick={handleCloseModal}
+                                disabled={restoring}
+                                className={styles.confirmModalCancelButton}
+                            >
+                                {t('common_cancel')}
+                            </button>
+                            <button
+                                onClick={handleConfirmRestore}
+                                disabled={restoring}
+                                className={styles.confirmModalConfirmButton}
+                            >
+                                {restoring ? t('editor_restoring') : t('editor_restoreVersion')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </>
     );
 };

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -182,6 +182,18 @@ export interface ArchiveResponse {
 }
 
 /**
+ * 버전 히스토리 아이템 인터페이스
+ */
+export interface VersionHistoryItem {
+    versionNumber: number;
+    title: string;
+    content: string;
+    contentFormat: 'markdown' | 'tiptap-json';
+    createdAt: string;
+    characterCount?: number;
+}
+
+/**
  * 아티클 응답 타입
  */
 export interface ArticleResponse {
@@ -291,6 +303,26 @@ export class ArticleService {
      */
     async archiveArticle(articleId: number): Promise<void> {
         return this.apiRequest(`/v1/articles/${articleId}/archive`, {
+            method: 'POST',
+        });
+    }
+
+    /**
+     * 아티클 버전 히스토리 조회
+     * GET /api/v1/articles/:id/versions
+     */
+    async getArticleVersions(articleId: number): Promise<VersionHistoryItem[]> {
+        return this.apiRequest(`/v1/articles/${articleId}/versions`, {
+            method: 'GET',
+        });
+    }
+
+    /**
+     * 특정 버전으로 복원
+     * POST /api/v1/articles/:id/restore/:versionNumber
+     */
+    async restoreVersion(articleId: number, versionNumber: number): Promise<ArticleResponse> {
+        return this.apiRequest(`/v1/articles/${articleId}/restore/${versionNumber}`, {
             method: 'POST',
         });
     }

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -309,7 +309,7 @@ export class ArticleService {
 
     /**
      * 아티클 버전 히스토리 조회
-     * GET /api/v1/articles/:id/versions
+     * GET /v1/articles/:id/versions
      */
     async getArticleVersions(articleId: number): Promise<VersionHistoryItem[]> {
         return this.apiRequest(`/v1/articles/${articleId}/versions`, {
@@ -319,7 +319,7 @@ export class ArticleService {
 
     /**
      * 특정 버전으로 복원
-     * POST /api/v1/articles/:id/restore/:versionNumber
+     * POST /v1/articles/:id/restore/:versionNumber
      */
     async restoreVersion(articleId: number, versionNumber: number): Promise<ArticleResponse> {
         return this.apiRequest(`/v1/articles/${articleId}/restore/${versionNumber}`, {

--- a/src/utils/timeFormat.ts
+++ b/src/utils/timeFormat.ts
@@ -1,0 +1,67 @@
+/**
+ * Format a date string to relative time (Notion-style)
+ * Examples:
+ * - "Just now" (< 1 min)
+ * - "2 minutes ago" (< 1 hour)
+ * - "3 hours ago" (< 24 hours)
+ * - "Yesterday at 3:24 PM" (< 48 hours)
+ * - "Jan 15 at 2:30 PM" (older)
+ */
+export function formatRelativeTime(dateString: string): string {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    const diffHours = Math.floor(diffMinutes / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    // Just now (< 1 min)
+    if (diffMinutes < 1) {
+        return 'Just now';
+    }
+
+    // Minutes ago (< 1 hour)
+    if (diffMinutes < 60) {
+        return `${diffMinutes} ${diffMinutes === 1 ? 'minute' : 'minutes'} ago`;
+    }
+
+    // Hours ago (< 24 hours)
+    if (diffHours < 24) {
+        return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`;
+    }
+
+    // Yesterday at time (< 48 hours)
+    if (diffDays === 1) {
+        const timeStr = date.toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        });
+        return `Yesterday at ${timeStr}`;
+    }
+
+    // Full date with time (older than 48 hours)
+    const monthStr = date.toLocaleString('en-US', { month: 'short' });
+    const dayStr = date.getDate();
+    const timeStr = date.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+    });
+
+    return `${monthStr} ${dayStr} at ${timeStr}`;
+}
+
+/**
+ * Calculate character count from content
+ */
+export function getCharacterCount(content: string | object): number {
+    if (typeof content === 'string') {
+        // Remove markdown syntax and count actual characters
+        return content.replace(/[#*_`~\[\]\(\)]/g, '').trim().length;
+    } else {
+        // For JSON content, stringify and count
+        return JSON.stringify(content).length;
+    }
+}

--- a/src/utils/timeFormat.ts
+++ b/src/utils/timeFormat.ts
@@ -54,14 +54,39 @@ export function formatRelativeTime(dateString: string): string {
 }
 
 /**
+ * Recursively extract plain text from TipTap JSON structure
+ */
+function extractTextFromTipTapJSON(node: any): string {
+    if (!node) return '';
+
+    // If it's a text node, return its text
+    if (node.type === 'text' && node.text) {
+        return node.text;
+    }
+
+    // If it has content array, recursively process children
+    if (Array.isArray(node.content)) {
+        return node.content.map(extractTextFromTipTapJSON).join('');
+    }
+
+    // If the node itself is an array
+    if (Array.isArray(node)) {
+        return node.map(extractTextFromTipTapJSON).join('');
+    }
+
+    return '';
+}
+
+/**
  * Calculate character count from content
+ * @param content - string (markdown) or TipTap JSON object
  */
 export function getCharacterCount(content: string | object): number {
     if (typeof content === 'string') {
         // Remove markdown syntax and count actual characters
         return content.replace(/[#*_`~\[\]\(\)]/g, '').trim().length;
     } else {
-        // For JSON content, stringify and count
-        return JSON.stringify(content).length;
+        // For TipTap JSON content, extract actual text
+        return extractTextFromTipTapJSON(content).length;
     }
 }

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -428,6 +428,8 @@ const koTranslations = {
   editor_saveTooltip: "저장 (Cmd+S)",
   editor_closeTooltip: "닫기 (Esc)",
   editor_characters: "자",
+  editor_restoreCompleted: "버전 복원 완료!",
+  editor_restoredToVersion: "버전 {versionNumber}로 복원되었습니다",
 };
 
 // 영어 번역 데이터
@@ -858,6 +860,8 @@ const enTranslations = {
   editor_saveTooltip: "Save (Cmd+S)",
   editor_closeTooltip: "Close (Esc)",
   editor_characters: " characters",
+  editor_restoreCompleted: "Version restored!",
+  editor_restoredToVersion: "Restored to version {versionNumber}",
 };
 
 export type TranslationKey = keyof typeof koTranslations;

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -411,6 +411,23 @@ const koTranslations = {
   editor_undo: "실행 취소 (Ctrl+Z)",
   editor_redo: "다시 실행 (Ctrl+Y)",
   editor_placeholder: "내용을 입력하세요...",
+
+  // Editor - Version History
+  editor_versionHistoryTitle: "버전 히스토리",
+  editor_closeEsc: "닫기 (Esc)",
+  editor_loadingVersions: "버전 불러오는 중...",
+  editor_noVersions: "버전 히스토리가 없습니다",
+  editor_restoring: "복원 중...",
+  editor_restoreVersion: "이 버전 복원",
+  editor_viewingVersion: "버전 보기",
+  editor_backToCurrent: "현재 버전으로",
+  editor_saved: "저장됨",
+  editor_unsaved: "저장 안 됨",
+  editor_saving: "저장 중...",
+  editor_versionHistoryTooltip: "버전 히스토리 (Cmd+H)",
+  editor_saveTooltip: "저장 (Cmd+S)",
+  editor_closeTooltip: "닫기 (Esc)",
+  editor_characters: "자",
 };
 
 // 영어 번역 데이터
@@ -824,6 +841,23 @@ const enTranslations = {
   editor_undo: "Undo (Ctrl+Z)",
   editor_redo: "Redo (Ctrl+Y)",
   editor_placeholder: "Enter content...",
+
+  // Editor - Version History
+  editor_versionHistoryTitle: "Version History",
+  editor_closeEsc: "Close (Esc)",
+  editor_loadingVersions: "Loading versions...",
+  editor_noVersions: "No version history available",
+  editor_restoring: "Restoring...",
+  editor_restoreVersion: "Restore this version",
+  editor_viewingVersion: "Viewing version from",
+  editor_backToCurrent: "Back to current",
+  editor_saved: "Saved",
+  editor_unsaved: "Unsaved",
+  editor_saving: "Saving...",
+  editor_versionHistoryTooltip: "Version History (Cmd+H)",
+  editor_saveTooltip: "Save (Cmd+S)",
+  editor_closeTooltip: "Close (Esc)",
+  editor_characters: " characters",
 };
 
 export type TranslationKey = keyof typeof koTranslations;


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-394](https://linear.app/chill-mato/issue/CHI-394/)

## 변경 요약
Notion 스타일의 풀스크린 에디터 UI를 구현하고, 버전 히스토리 조회 및 복원 기능을 추가

## 주요 변경사항

### 1. Notion 스타일 풀스크린 에디터 UI 개선
- 제목 입력 필드
- 중앙 정렬 콘텐츠 영역 (max-width: 750px)
- 미니멀한 인터페이스 (헤더 바 제거)
- 우측 상단 액션 버튼 배치 (버전 히스토리, 저장, 닫기)

### 2. 버전 히스토리 기능 구현
- 우측 슬라이드 패널로 모든 버전 목록 표시
- 버전 클릭 시 미리보기 배너 표시
- 이전 버전으로 복원 기능 (Restore 버튼)
- 키보드 단축키 지원
  - `Cmd/Ctrl+H`: 버전 히스토리 패널 토글
  - `Escape`: 패널 및 미리보기 닫기
- 패널 닫을 때 미리보기 배너도 함께 닫힘

### 3. 새로운 컴포넌트 및 유틸 추가
- `VersionHistoryPanel` 컴포넌트 추가
- `timeFormat` 유틸 추가 (상대적 시간 표시)
- `articleService`에 `getArticleVersions`, `restoreArticleVersion` API 메서드 추가

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인
  - [x] 풀스크린 에디터 UI 렌더링
  - [x] 버전 히스토리 패널 열기/닫기
  - [x] 버전 미리보기
  - [x] 버전 복원
  - [x] 키보드 단축키 동작

## 스크린샷/데모 (선택)
<!-- UI 변경이 크므로 스크린샷 첨부를 권장합니다 -->
<img width="1800" height="1009" alt="스크린샷 2025-10-16 23 34 18" src="https://github.com/user-attachments/assets/79ceb126-a193-42ff-a387-3586c6088df8" />
<img width="1800" height="1007" alt="image" src="https://github.com/user-attachments/assets/add6ca40-6026-4124-ad69-54ce16afca76" />

## 기타 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version history panel: browse, preview, and restore previous article versions
  * Restore confirmation toast with brief confetti and undo-friendly flow
  * Keyboard shortcut (Cmd/Ctrl+H) to open version history

* **Improvements**
  * Redesigned editor layout and responsive refinements for desktop, tablet, and mobile
  * Top-right action bar with save status indicators (saved, saving, unsaved) and version actions
  * Version preview banner that disables editing while viewing past versions

* **Localization**
  * Added English and Korean strings for version history UI and actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->