### PR TITLE
[CHI-396] 플랫폼 Injector에 파비콘 수집 기능 추가

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -10,6 +10,7 @@ import type {
   SidebarState,
   SidebarStateResponse
 } from '../types/messages';
+import type { ScrapExtractedData } from '../types/scrap';
 
 // WXT Analytics는 자동 초기화됨
 
@@ -556,15 +557,10 @@ export default defineBackground(() => {
   }
 
   /**
-   * Save container text sent by LinkedIn button to API
+   * Save scraped content from any platform injector to API
+   * Handles content from LinkedIn, X, Reddit, Threads, YouTube
    */
-  async function handleScrapExtracted(data: {
-    content: string;
-    title?: string;
-    url?: string;
-    faviconUrl?: string;
-    siteName?: string;
-  }) {
+  async function handleScrapExtracted(data: ScrapExtractedData) {
     if (!data?.content || !data.content.trim()) {
       throw new Error('Empty content');
     }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -558,18 +558,26 @@ export default defineBackground(() => {
   /**
    * Save container text sent by LinkedIn button to API
    */
-  async function handleScrapExtracted(data: { content: string; title?: string; url?: string }) {
+  async function handleScrapExtracted(data: {
+    content: string;
+    title?: string;
+    url?: string;
+    faviconUrl?: string;
+    siteName?: string;
+  }) {
     if (!data?.content || !data.content.trim()) {
       throw new Error('Empty content');
     }
 
-    const pickTitle = () => (data.title && data.title.trim()) || 'LinkedIn Feed';
+    const pickTitle = () => (data.title && data.title.trim()) || data.siteName || 'LinkedIn Feed';
 
     const scrapResult = {
       content: data.content,
       metadata: {
         title: pickTitle(),
         url: data.url || '',
+        favicon: data.faviconUrl || '',
+        siteName: data.siteName || '',
       },
       selectionOnly: false,
       timestamp: new Date().toISOString(),

--- a/src/types/scrap.ts
+++ b/src/types/scrap.ts
@@ -1,0 +1,26 @@
+/**
+ * Scrap Types
+ *
+ * 스크랩 관련 타입 정의
+ */
+
+/**
+ * 플랫폼 인젝터에서 추출한 스크랩 데이터
+ * LinkedIn, X, Reddit, Threads, YouTube 등 모든 플랫폼에서 사용
+ */
+export interface ScrapExtractedData {
+  /** 스크랩된 콘텐츠 (마크다운 형식) */
+  content: string;
+
+  /** 스크랩 제목 */
+  title?: string;
+
+  /** 스크랩된 페이지 URL */
+  url?: string;
+
+  /** 파비콘 URL */
+  faviconUrl?: string;
+
+  /** 플랫폼 이름 (예: 'LinkedIn', 'X', 'Reddit') */
+  siteName?: string;
+}

--- a/src/utils/faviconExtractor.ts
+++ b/src/utils/faviconExtractor.ts
@@ -1,0 +1,91 @@
+/**
+ * Favicon Extraction Utility
+ *
+ * 웹 페이지에서 favicon URL을 추출하는 공통 유틸리티
+ * 모든 플랫폼 injector에서 사용됨
+ */
+
+// 캐시 변수
+let cachedFavicon: string | null = null;
+let cachedOrigin: string | null = null;
+
+/**
+ * URL이 유효한 favicon URL인지 검증
+ * @param url 검증할 URL
+ * @returns 유효한 favicon URL이면 true
+ */
+function isValidFaviconUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+
+    // data URI인 경우 크기 제한 (50KB)
+    if (parsed.protocol === 'data:') {
+      return url.length < 50000;
+    }
+
+    // http, https만 허용
+    return ['http:', 'https:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 현재 페이지에서 favicon URL을 추출
+ *
+ * 우선순위:
+ * 1. 32x32 크기의 icon
+ * 2. PNG 타입의 icon
+ * 3. 일반 icon
+ * 4. shortcut icon
+ * 5. apple-touch-icon
+ * 6. 폴백: /favicon.ico
+ *
+ * @returns favicon URL (항상 유효한 문자열 반환)
+ */
+export function extractFavicon(): string {
+  try {
+    // origin이 변경되면 캐시 초기화 (SPA 네비게이션 대응)
+    if (cachedOrigin !== window.location.origin) {
+      cachedFavicon = null;
+      cachedOrigin = window.location.origin;
+    }
+
+    // 캐시된 결과가 있으면 반환
+    if (cachedFavicon) {
+      return cachedFavicon;
+    }
+
+    // 우선순위에 따라 favicon 검색
+    const selectors = [
+      'link[rel="icon"][sizes="32x32"]',
+      'link[rel="icon"][type="image/png"]',
+      'link[rel="icon"]',
+      'link[rel="shortcut icon"]',
+      'link[rel="apple-touch-icon"]'
+    ];
+
+    for (const selector of selectors) {
+      const iconLink = document.querySelector(selector) as HTMLLinkElement | null;
+      if (iconLink?.href && isValidFaviconUrl(iconLink.href)) {
+        cachedFavicon = iconLink.href;
+        return cachedFavicon;
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to extract favicon:', error);
+  }
+
+  // 폴백: /favicon.ico
+  const fallback = `${window.location.origin}/favicon.ico`;
+  cachedFavicon = fallback;
+  return fallback;
+}
+
+/**
+ * 캐시 초기화 (테스트용)
+ */
+export function resetFaviconCache(): void {
+  cachedFavicon = null;
+  cachedOrigin = null;
+}

--- a/src/utils/linkedinInjector.ts
+++ b/src/utils/linkedinInjector.ts
@@ -2,6 +2,7 @@
 import { browser } from 'wxt/browser';
 import { WHITE_LOGO_URL, LINKEDIN_SELECTORS, LINKEDIN_STYLE_TEXT } from './constants';
 import { trackPlatformContentScrapedBridge } from '../analytics/bridge';
+import { extractFavicon } from './faviconExtractor';
 
 // 대상 부모 컨테이너: feed-shared-control-menu display-flex
 //   feed-shared-update-v2__control-menu absolute text-align-right
@@ -123,17 +124,6 @@ function ensureStylesInjected(): void {
   style.id = 'tyquill-li-action-styles';
   style.textContent = LINKEDIN_STYLE_TEXT;
   document.head.appendChild(style);
-}
-
-function extractFavicon(): string | null {
-  // Try to find favicon from link tags
-  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
-  if (iconLink?.href) {
-    return iconLink.href;
-  }
-
-  // Fallback to default favicon.ico
-  return `${window.location.origin}/favicon.ico`;
 }
 
 async function doScrapFromButton(button: HTMLButtonElement): Promise<void> {

--- a/src/utils/linkedinInjector.ts
+++ b/src/utils/linkedinInjector.ts
@@ -125,12 +125,26 @@ function ensureStylesInjected(): void {
   document.head.appendChild(style);
 }
 
+function extractFavicon(): string | null {
+  // Try to find favicon from link tags
+  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
+  if (iconLink?.href) {
+    return iconLink.href;
+  }
+
+  // Fallback to default favicon.ico
+  return `${window.location.origin}/favicon.ico`;
+}
+
 async function doScrapFromButton(button: HTMLButtonElement): Promise<void> {
   const container = button.closest('.fie-impression-container') as HTMLElement | null;
   const content = collectContainerMarkdown(container);
   const author = extractSenderName(container);
   const title = author ? `Linkedin 피드 | ${author}` : 'Linkedin 피드';
   const permalink = extractPermalink(container) || window.location.href;
+
+  // Extract favicon
+  const faviconUrl = extractFavicon();
 
   // Track scraping event
   try {
@@ -153,7 +167,13 @@ async function doScrapFromButton(button: HTMLButtonElement): Promise<void> {
   try {
     await browser.runtime.sendMessage({
       action: 'scrapExtracted',
-      data: { content, title, url: permalink }
+      data: {
+        content,
+        title,
+        url: permalink,
+        faviconUrl,
+        siteName: 'LinkedIn'
+      }
     });
   } catch (err) {}
 }

--- a/src/utils/redditInjector.ts
+++ b/src/utils/redditInjector.ts
@@ -148,6 +148,17 @@ function ensureStylesInjected(): void {
   document.head.appendChild(style);
 }
 
+function extractFavicon(): string | null {
+  // Try to find favicon from link tags
+  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
+  if (iconLink?.href) {
+    return iconLink.href;
+  }
+
+  // Fallback to default favicon.ico
+  return `${window.location.origin}/favicon.ico`;
+}
+
 function createTyquillButton(): HTMLDivElement {
   const wrapper = document.createElement('div');
   wrapper.className = 'tyquill-reddit-action-wrapper';
@@ -375,6 +386,9 @@ async function doScrapFromRedditButton(buttonEl: HTMLElement): Promise<void> {
 
   const scrapTitle = title || `Reddit Post from r/${subreddit}`;
 
+  // Extract favicon
+  const faviconUrl = extractFavicon();
+
   // Track the scraping event
   try {
     await trackPlatformContentScrapedBridge({
@@ -401,7 +415,9 @@ async function doScrapFromRedditButton(buttonEl: HTMLElement): Promise<void> {
       data: {
         content: fullContent,
         title: scrapTitle,
-        url: url
+        url: url,
+        faviconUrl,
+        siteName: 'Reddit'
       }
     });
   } catch (error) {

--- a/src/utils/redditInjector.ts
+++ b/src/utils/redditInjector.ts
@@ -1,6 +1,7 @@
 import { browser } from 'wxt/browser';
 import { WHITE_LOGO_URL } from './constants';
 import { trackPlatformContentScrapedBridge } from '../analytics/bridge';
+import { extractFavicon } from './faviconExtractor';
 
 type CleanupFn = () => void;
 
@@ -146,17 +147,6 @@ function ensureStylesInjected(): void {
   style.id = 'tyquill-reddit-action-styles';
   style.textContent = REDDIT_STYLE_TEXT;
   document.head.appendChild(style);
-}
-
-function extractFavicon(): string | null {
-  // Try to find favicon from link tags
-  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
-  if (iconLink?.href) {
-    return iconLink.href;
-  }
-
-  // Fallback to default favicon.ico
-  return `${window.location.origin}/favicon.ico`;
 }
 
 function createTyquillButton(): HTMLDivElement {

--- a/src/utils/threadsInjector.ts
+++ b/src/utils/threadsInjector.ts
@@ -1,6 +1,7 @@
 import { browser } from 'wxt/browser';
 import { WHITE_LOGO_URL, THREADS_SELECTORS, THREADS_STYLE_TEXT } from './constants';
 import { trackPlatformContentScrapedBridge } from '../analytics/bridge';
+import { extractFavicon } from './faviconExtractor';
 
 type CleanupFn = () => void;
 
@@ -24,17 +25,6 @@ function ensureStylesInjected(): void {
   style.id = 'tyquill-threads-action-styles';
   style.textContent = THREADS_STYLE_TEXT;
   document.head.appendChild(style);
-}
-
-function extractFavicon(): string | null {
-  // Try to find favicon from link tags
-  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
-  if (iconLink?.href) {
-    return iconLink.href;
-  }
-
-  // Fallback to default favicon.ico
-  return `${window.location.origin}/favicon.ico`;
 }
 
 function createInlineTyquillSVG(): SVGElement {

--- a/src/utils/threadsInjector.ts
+++ b/src/utils/threadsInjector.ts
@@ -26,6 +26,17 @@ function ensureStylesInjected(): void {
   document.head.appendChild(style);
 }
 
+function extractFavicon(): string | null {
+  // Try to find favicon from link tags
+  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
+  if (iconLink?.href) {
+    return iconLink.href;
+  }
+
+  // Fallback to default favicon.ico
+  return `${window.location.origin}/favicon.ico`;
+}
+
 function createInlineTyquillSVG(): SVGElement {
   const svgNS = 'http://www.w3.org/2000/svg';
   const svg = document.createElementNS(svgNS, 'svg');
@@ -396,6 +407,9 @@ async function doScrapFromThreadsButton(buttonEl: Element): Promise<void> {
     content = content ? `${content}\n\n${images.join('\n')}` : images.join('\n');
   }
 
+  // Extract favicon
+  const faviconUrl = extractFavicon();
+
   // Track scraping event
   try {
     await trackPlatformContentScrapedBridge({
@@ -417,7 +431,13 @@ async function doScrapFromThreadsButton(buttonEl: Element): Promise<void> {
   try {
     await browser.runtime.sendMessage({
       action: 'scrapExtracted',
-      data: { content, title, url }
+      data: {
+        content,
+        title,
+        url,
+        faviconUrl,
+        siteName: 'Threads'
+      }
     });
   } catch {}
 }

--- a/src/utils/xInjector.ts
+++ b/src/utils/xInjector.ts
@@ -23,6 +23,17 @@ function ensureStylesInjected(): void {
   document.head.appendChild(style);
 }
 
+function extractFavicon(): string | null {
+  // Try to find favicon from link tags
+  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
+  if (iconLink?.href) {
+    return iconLink.href;
+  }
+
+  // Fallback to default favicon.ico
+  return `${window.location.origin}/favicon.ico`;
+}
+
 function ensureGlobalTooltip(): HTMLDivElement {
   if (tyquillXTooltipEl && document.body.contains(tyquillXTooltipEl)) return tyquillXTooltipEl;
   const el = document.createElement('div');
@@ -459,6 +470,9 @@ async function doScrapFromXButton(buttonEl: Element): Promise<void> {
     content = content ? `${content}\n\n${images.join('\n')}` : images.join('\n');
   }
 
+  // Extract favicon
+  const faviconUrl = extractFavicon();
+
   // Track scraping event
   try {
     await trackPlatformContentScrapedBridge({
@@ -475,7 +489,13 @@ async function doScrapFromXButton(buttonEl: Element): Promise<void> {
   try {
     await browser.runtime.sendMessage({
       action: 'scrapExtracted',
-      data: { content, title, url }
+      data: {
+        content,
+        title,
+        url,
+        faviconUrl,
+        siteName: 'X'
+      }
     });
   } catch {}
 }

--- a/src/utils/xInjector.ts
+++ b/src/utils/xInjector.ts
@@ -2,6 +2,7 @@ import { browser } from 'wxt/browser';
 import { WHITE_LOGO_URL, X_SELECTORS } from './constants';
 import { X_STYLE_TEXT } from './constants';
 import { trackPlatformContentScrapedBridge } from '../analytics/bridge';
+import { extractFavicon } from './faviconExtractor';
 
 type CleanupFn = () => void;
 
@@ -21,17 +22,6 @@ function ensureStylesInjected(): void {
   style.id = 'tyquill-x-action-styles';
   style.textContent = X_STYLE_TEXT;
   document.head.appendChild(style);
-}
-
-function extractFavicon(): string | null {
-  // Try to find favicon from link tags
-  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
-  if (iconLink?.href) {
-    return iconLink.href;
-  }
-
-  // Fallback to default favicon.ico
-  return `${window.location.origin}/favicon.ico`;
 }
 
 function ensureGlobalTooltip(): HTMLDivElement {

--- a/src/utils/youtubeInjector.ts
+++ b/src/utils/youtubeInjector.ts
@@ -89,6 +89,17 @@ function ensureStylesInjected(): void {
   document.head.appendChild(style);
 }
 
+function extractFavicon(): string | null {
+  // Try to find favicon from link tags
+  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
+  if (iconLink?.href) {
+    return iconLink.href;
+  }
+
+  // Fallback to default favicon.ico
+  return `${window.location.origin}/favicon.ico`;
+}
+
 function applyIconTheme(target?: ParentNode): void {
   const isDark = isYouTubeDarkTheme();
   const filterValue = isDark ? 'none' : 'invert(1)';
@@ -221,6 +232,9 @@ async function doScrapFromYouTubeButton(): Promise<boolean> {
     const main = extractDescription();
     const content = normalizeText(main);
 
+    // Extract favicon
+    const faviconUrl = extractFavicon();
+
     // Track scraping event
     try {
       await trackPlatformContentScrapedBridge({
@@ -240,7 +254,13 @@ async function doScrapFromYouTubeButton(): Promise<boolean> {
 
     await browser.runtime.sendMessage({
       action: 'scrapExtracted',
-      data: { content, title: `YouTube | ${title}`, url }
+      data: {
+        content,
+        title: `YouTube | ${title}`,
+        url,
+        faviconUrl,
+        siteName: 'YouTube'
+      }
     });
     return true;
   } catch {

--- a/src/utils/youtubeInjector.ts
+++ b/src/utils/youtubeInjector.ts
@@ -1,6 +1,7 @@
 import { browser } from 'wxt/browser';
 import { WHITE_LOGO_URL, YT_SELECTORS, YT_STYLE_TEXT } from './constants';
 import { trackPlatformContentScrapedBridge } from '../analytics/bridge';
+import { extractFavicon } from './faviconExtractor';
 
 type CleanupFn = () => void;
 
@@ -87,17 +88,6 @@ function ensureStylesInjected(): void {
   style.id = 'tyquill-yt-action-styles';
   style.textContent = YT_STYLE_TEXT;
   document.head.appendChild(style);
-}
-
-function extractFavicon(): string | null {
-  // Try to find favicon from link tags
-  const iconLink = document.querySelector('link[rel*="icon"]') as HTMLLinkElement | null;
-  if (iconLink?.href) {
-    return iconLink.href;
-  }
-
-  // Fallback to default favicon.ico
-  return `${window.location.origin}/favicon.ico`;
 }
 
 function applyIconTheme(target?: ParentNode): void {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-396](https://linear.app/chill-mato/issue/CHI-396)

## 변경 요약
플랫폼별 Injector(LinkedIn, X, Reddit, Threads, YouTube)에서 스크랩 시 파비콘을 수집하지 않던 문제 해결

## 주요 변경사항
### 플랫폼 인젝터에 파비콘 추출 기능 추가
- **파일**: `src/utils/{linkedin,x,reddit,threads,youtube}Injector.ts`
- 각 인젝터에 `extractFavicon()` 함수 추가
  - `<link rel="icon">` 태그에서 favicon URL 추출
  - 없을 경우 `/favicon.ico` 폴백
- 스크랩 메시지에 `faviconUrl`과 `siteName` 필드 추가

### Background Script 업데이트
- **파일**: `src/entrypoints/background.ts`
- `handleScrapExtracted` 함수 타입 시그니처 확장
  - `faviconUrl?: string` 파라미터 추가
  - `siteName?: string` 파라미터 추가
- 스크랩 메타데이터에 favicon 정보 포함하여 API 전송

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 동작 확인

## 스크린샷/데모 (선택)
<!-- 각 플랫폼에서 스크랩 후 파비콘이 표시되는 스크린샷 첨부 예정 -->
<img width="846" height="1370" alt="image" src="https://github.com/user-attachments/assets/c8da89a6-45c0-4647-a855-25fb2522beb4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scraped content now includes site favicon and platform name metadata (LinkedIn, Reddit, Threads, X, YouTube) for improved identification and display.
  * Title selection improved with smarter fallbacks to use available title/site name when present, yielding more accurate scrap titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->