### PR TITLE
[CHI-398] SaaS가 Tyquill Extension을 열 수 있게 변경

### DIFF
--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -173,6 +173,73 @@ const App: React.FC = () => {
     };
   }, [initializeLanguage]);
 
+  // Web client -> Extension: 설치 감지 프로토콜 처리 (TYQUILL_GET_AUTH_REQUEST)
+  useEffect(() => {
+    const handleAuthHandshake = async (event: MessageEvent) => {
+      // Only accept messages from our SaaS domains: localhost or *.tyquill.ai
+      try {
+        const originHost = new URL(event.origin).hostname;
+        const isAllowed = originHost === 'localhost' || originHost.endsWith('tyquill.ai');
+        if (!isAllowed) return;
+      } catch { return; }
+
+      const data = event.data as any;
+      if (!data || typeof data !== 'object') return;
+
+      if (data.type === 'TYQUILL_GET_AUTH_REQUEST' && data.source === 'tyquill-web-client') {
+        try {
+          const response = await browser.runtime.sendMessage({ action: 'getAuthState' });
+          window.postMessage({
+            type: 'TYQUILL_AUTH_RESPONSE',
+            source: 'tyquill-extension',
+            authState: response?.authState || null,
+          }, event.origin);
+        } catch (_error) {
+          window.postMessage({
+            type: 'TYQUILL_AUTH_RESPONSE',
+            source: 'tyquill-extension',
+            authState: null,
+          }, event.origin);
+        }
+      }
+    };
+
+    window.addEventListener('message', handleAuthHandshake);
+    return () => window.removeEventListener('message', handleAuthHandshake);
+  }, []);
+
+  // Web client -> Extension: 사이드패널 열기 브리지 (설치 감지 ACK 포함)
+  useEffect(() => {
+    const handleWebClientOpenRequest = async (event: MessageEvent) => {
+      // Only accept messages from our SaaS domains: localhost or *.tyquill.ai
+      try {
+        const originHost = new URL(event.origin).hostname;
+        const isAllowed = originHost === 'localhost' || originHost.endsWith('tyquill.ai');
+        if (!isAllowed) return;
+      } catch { return; }
+      const data = event.data as any;
+      if (!data || typeof data !== 'object') return;
+
+      if (data.type === 'TYQUILL_OPEN_EXTENSION' && data.source === 'tyquill-web-client') {
+        try {
+          // 설치 감지용 ACK 반환
+          window.postMessage({
+            type: 'TYQUILL_EXTENSION_ACK',
+            source: 'tyquill-extension',
+          }, event.origin);
+        } catch {}
+
+        try {
+          // 기존 플로팅 버튼과 동일 경로: background에 사이드패널 열기 요청
+          await browser.runtime.sendMessage({ action: 'openSidePanel' });
+        } catch {}
+      }
+    };
+
+    window.addEventListener('message', handleWebClientOpenRequest);
+    return () => window.removeEventListener('message', handleWebClientOpenRequest);
+  }, []);
+
 
   // DOM이 준비되면 FloatingButton 표시
   useEffect(() => {


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-398](https://linear.app/chill-mato/issue/CHI-398/)

## 변경 요약
**Tyquill SaaS에서 Extension이 설치되었는지 확인하고, 설치되어 있다면 사이드패널을 여는 로직을 추가합니다.**

웹 클라이언트와 확장 프로그램 간 설치 감지/인증 상태 조회 및 사이드패널 열기 브리지를 추가했습니다. `TYQUILL_GET_AUTH_REQUEST` 메시지에 대해 확장 프로그램이 인증 상태(`TYQUILL_AUTH_RESPONSE`)를 반환하고, `TYQUILL_OPEN_EXTENSION` 요청 시 설치 확인 ACK(`TYQUILL_EXTENSION_ACK`)와 함께 백그라운드에 사이드패널 열기를 요청합니다.

## 주요 변경사항
- `src/content/App.tsx`
  - Web → Extension 인증 핸드셰이크 처리: `TYQUILL_GET_AUTH_REQUEST` → `TYQUILL_AUTH_RESPONSE`
  - Web → Extension 사이드패널 열기 브리지: `TYQUILL_OPEN_EXTENSION` → `TYQUILL_EXTENSION_ACK` 및 `openSidePanel` 메시지
  - 오리진 검증: `localhost` 또는 `*.tyquill.ai` 만 허용

## 테스트
- [x] 빌드 확인
- [x] 허용 오리진에서의 메시지 처리 확인 (`localhost`, `*.tyquill.ai`)
- [x] 인증 상태 조회 요청 시 `TYQUILL_AUTH_RESPONSE` 수신 확인 (로그인/비로그인 케이스)
- [x] 사이드패널 열기 요청 시 `TYQUILL_EXTENSION_ACK` 수신 및 사이드패널 정상 오픈 확인

## 기타 참고사항
- 보안: 오리진 체크 실패 시 즉시 무시하도록 가드 처리
- 현재 origin: `localhost`, `*.tyquill.ai`
- 회귀 영향: `FloatingButton` 경로와 동일한 `openSidePanel` 메시지를 사용하므로 기능 회귀 가능성 낮음
