### PR TITLE
[CHI-418] RegenerateModal Sources에 PDF 포함 및 무한스크롤 구현

### DIFF
--- a/src/components/sidepanel/RegenerateModal/RegenerateModal.tsx
+++ b/src/components/sidepanel/RegenerateModal/RegenerateModal.tsx
@@ -290,6 +290,7 @@ const RegenerateModal: React.FC<RegenerateModalProps> = ({
                 selectedScrapIds={selectedScrapIds}
                 onSelectionChange={handleSelectionChange}
                 disabled={isRegenerating}
+                initialScraps={article.scraps}
               />
             </div>
 

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/AddSourcePanel.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/AddSourcePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { IoClose, IoSearch } from 'react-icons/io5';
 import { ScrapResponse } from '../../../../services/scrapService';
 import { useI18n } from '../../../../hooks/useI18n';
@@ -12,6 +12,9 @@ interface AddSourcePanelProps {
   onToggleSource: (scrapId: number) => void;
   onClose: () => void;
   disabled?: boolean;
+  onLoadMore: () => void;
+  hasMore: boolean;
+  isLoading: boolean;
 }
 
 const AddSourcePanel: React.FC<AddSourcePanelProps> = ({
@@ -20,10 +23,14 @@ const AddSourcePanel: React.FC<AddSourcePanelProps> = ({
   onToggleSource,
   onClose,
   disabled,
+  onLoadMore,
+  hasMore,
+  isLoading,
 }) => {
   const { t } = useI18n();
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
 
   // Optimized search with debounced query
   const filteredScraps = useMemo(() => {
@@ -52,6 +59,24 @@ const AddSourcePanel: React.FC<AddSourcePanelProps> = ({
   const handleClearSearch = () => {
     setSearchQuery('');
   };
+
+  // Infinite scroll with IntersectionObserver
+  useEffect(() => {
+    const trigger = loadMoreTriggerRef.current;
+    if (!trigger || !hasMore || isLoading) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onLoadMore();
+        }
+      },
+      { threshold: 0.1, rootMargin: '100px' }
+    );
+
+    observer.observe(trigger);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, onLoadMore]);
 
   return (
     <div className={styles.addSourcePanel} role="region" aria-label="Add source panel">
@@ -106,15 +131,28 @@ const AddSourcePanel: React.FC<AddSourcePanelProps> = ({
               : t('regenerateModal_noAvailableSources')}
           </div>
         ) : (
-          filteredScraps.map((scrap) => (
-            <SourceListItem
-              key={scrap.scrapId}
-              scrap={scrap}
-              isSelected={selectedScrapIds.includes(scrap.scrapId)}
-              onToggle={onToggleSource}
-              disabled={disabled}
-            />
-          ))
+          <>
+            {filteredScraps.map((scrap) => (
+              <SourceListItem
+                key={scrap.scrapId}
+                scrap={scrap}
+                isSelected={selectedScrapIds.includes(scrap.scrapId)}
+                onToggle={onToggleSource}
+                disabled={disabled}
+              />
+            ))}
+
+            {/* Infinite scroll trigger */}
+            {hasMore && !searchQuery && (
+              <div ref={loadMoreTriggerRef} className={styles.loadMoreTrigger}>
+                {isLoading && (
+                  <div className={styles.loadingIndicator}>
+                    {t('common_loading')}...
+                  </div>
+                )}
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.module.css
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.module.css
@@ -707,6 +707,31 @@
   cursor: not-allowed;
 }
 
+/* ========== Infinite Scroll ========== */
+.loadMoreTrigger {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  min-height: 40px;
+}
+
+.loadingIndicator {
+  font-size: 13px;
+  color: rgba(55, 53, 47, 0.5);
+  font-weight: 400;
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 /* ========== Mobile Responsive ========== */
 @media (max-width: 480px) {
   .sourcePill {

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
@@ -24,15 +24,19 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
 
-  // Fetch all scraps on mount
+  // Fetch all scraps on mount (including PDFs)
   useEffect(() => {
     const fetchScraps = async () => {
       setIsLoadingScraps(true);
       setError(null);
 
       try {
-        const scraps = await scrapService.getScraps();
-        setAllScraps(scraps);
+        // Use v3 API without type filter to get both webclips and uploads (PDFs)
+        const response = await scrapService.getScrapsV3({
+          sortBy: 'updated_at',
+          sortOrder: 'DESC',
+        });
+        setAllScraps(response.scraps);
         setRetryCount(0); // Reset retry count on success
       } catch (err) {
         const errorMessage = err instanceof Error

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
@@ -10,12 +10,14 @@ interface SourcesSectionProps {
   selectedScrapIds: number[];
   onSelectionChange: (scrapIds: number[]) => void;
   disabled?: boolean;
+  initialScraps?: ScrapResponse[]; // Article's scraps for ensuring they're always available
 }
 
 const SourcesSection: React.FC<SourcesSectionProps> = ({
   selectedScrapIds,
   onSelectionChange,
   disabled,
+  initialScraps = [],
 }) => {
   const { t } = useI18n();
   const [allScraps, setAllScraps] = useState<ScrapResponse[]>([]);
@@ -23,8 +25,10 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
 
-  // Fetch all scraps on mount (including PDFs)
+  // Fetch all scraps on mount (including PDFs) with pagination
   useEffect(() => {
     const fetchScraps = async () => {
       setIsLoadingScraps(true);
@@ -33,10 +37,20 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
       try {
         // Use v3 API without type filter to get both webclips and uploads (PDFs)
         const response = await scrapService.getScrapsV3({
+          page: currentPage,
+          limit: 50,
           sortBy: 'updated_at',
           sortOrder: 'DESC',
         });
-        setAllScraps(response.scraps);
+
+        // Merge with existing scraps (avoid duplicates)
+        setAllScraps(prev => {
+          const existingIds = new Set(prev.map(s => s.scrapId));
+          const newScraps = response.scraps.filter(s => !existingIds.has(s.scrapId));
+          return [...prev, ...newScraps];
+        });
+
+        setHasMore(response.hasMore);
         setRetryCount(0); // Reset retry count on success
       } catch (err) {
         const errorMessage = err instanceof Error
@@ -50,7 +64,18 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
     };
 
     fetchScraps();
-  }, [t, retryCount]);
+  }, [t, retryCount, currentPage]);
+
+  // Initialize with article's scraps to ensure they're always available for pills
+  useEffect(() => {
+    if (initialScraps.length > 0) {
+      setAllScraps(prev => {
+        const existingIds = new Set(prev.map(s => s.scrapId));
+        const uniqueInitialScraps = initialScraps.filter(s => !existingIds.has(s.scrapId));
+        return [...uniqueInitialScraps, ...prev];
+      });
+    }
+  }, [initialScraps]);
 
   // Get selected scraps for display
   const selectedScraps = allScraps.filter((scrap) =>
@@ -89,6 +114,12 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
   const handleRetry = () => {
     setRetryCount((prev) => prev + 1);
   };
+
+  const handleLoadMore = useCallback(() => {
+    if (!isLoadingScraps && hasMore) {
+      setCurrentPage(prev => prev + 1);
+    }
+  }, [isLoadingScraps, hasMore]);
 
   if (error) {
     return (
@@ -138,6 +169,9 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
           onToggleSource={handleToggleSource}
           onClose={handleClosePanel}
           disabled={disabled}
+          onLoadMore={handleLoadMore}
+          hasMore={hasMore}
+          isLoading={isLoadingScraps}
         />
       )}
     </div>


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- Linear 이슈를 링크해주세요 -->
Closes: [CHI-418](https://linear.app/chill-mato/issue/CHI-418/)

## 변경 요약
<!-- 주요 변경사항을 한두 줄로 요약해주세요 -->
RegenerateModal의 Sources 섹션에 PDF 포함, article 연관 스크랩 pill 표시, 무한스크롤 기능 추가

## 주요 변경사항

### 1. PDF 스크랩 포함
- `scrapService.getScraps()` (v2) → `getScrapsV3()` 변경
- `type` 필터 없이 호출하여 webclip + upload(PDF) 모두 조회
- 기존에는 webclip만 표시되어 PDF 업로드 스크랩이 목록에서 제외되던 문제 해결

### 2. Article 연관 스크랩 pill 표시 보장
- `RegenerateModal`에서 `article.scraps`를 `initialScraps` props로 `SourcesSection`에 전달
- `allScraps`에 `initialScraps` 병합 (중복 제거)
- Article과 연관된 스크랩이 첫 페이지(50개)에 없어도 pill로 표시되도록 보장

### 3. 무한스크롤 구현
- `IntersectionObserver` API를 사용한 무한스크롤
- 페이지네이션 (50개씩), `hasMore` 상태 관리
- 스크롤 하단 100px 전에 자동 로드
- 로딩 인디케이터 추가
- 검색 중에는 무한스크롤 비활성화


## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

## 스크린샷/데모 (선택)
<!-- UI 변경/신규 기능이 있다면 첨부 -->

## 기타 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Infinite scroll support for sources: automatically load additional items as you scroll to the bottom of the list
  * Loading indicator with fade-in animation displays during source retrieval
  * Pre-populated source list capability for improved startup experience

* **Refactor**
  * Source fetching mechanism updated to use pagination for better performance and memory efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->