### PR TITLE
[CHI-436] UUID 마이그레이션: 프론트엔드 타입 시스템 전환

### DIFF
--- a/src/components/content/Sidebar/Sidebar.tsx
+++ b/src/components/content/Sidebar/Sidebar.tsx
@@ -238,8 +238,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
     setCurrentPage({ type: menu as PageType });
   };
 
-  const handleNavigateToDetail = (articleId: number) => {
-    setCurrentPage({ type: 'archive-detail', draftId: articleId.toString() });
+  const handleNavigateToDetail = (articleId: string) => { // UUID
+    setCurrentPage({ type: 'archive-detail', draftId: articleId });
   };
 
   const handleArchiveBack = () => {

--- a/src/components/editor/EditorApp.tsx
+++ b/src/components/editor/EditorApp.tsx
@@ -14,7 +14,7 @@ import styles from './EditorApp.module.css';
 import '../sidepanel/Editor/NotionEditor.module.css';
 
 interface EditorData {
-  articleId: number;
+  articleId: string; // UUID
   title: string;
   content: string;
   contentFormat?: 'markdown' | 'tiptap-json';

--- a/src/components/editor/VersionHistoryPanel.tsx
+++ b/src/components/editor/VersionHistoryPanel.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '../../hooks/useI18n';
 import styles from './EditorApp.module.css';
 
 interface VersionHistoryPanelProps {
-    articleId: number;
+    articleId: string; // UUID
     currentVersionNumber?: number;
     onClose: () => void;
     onVersionSelect: (version: VersionHistoryItem) => void;

--- a/src/components/sidepanel/FolderSidebar/FolderSidebar.tsx
+++ b/src/components/sidepanel/FolderSidebar/FolderSidebar.tsx
@@ -15,7 +15,7 @@ import Tooltip from '../../common/Tooltip';
  */
 interface DragData {
   type: 'SCRAP' | 'ARTICLE';
-  id: number;
+  id: string; // UUID
 }
 
 function isDragData(data: unknown): data is DragData {
@@ -25,7 +25,7 @@ function isDragData(data: unknown): data is DragData {
     'type' in data &&
     'id' in data &&
     (data.type === 'SCRAP' || data.type === 'ARTICLE') &&
-    typeof data.id === 'number'
+    typeof data.id === 'string'
   );
 }
 

--- a/src/components/sidepanel/FolderTreeItem/FolderTreeItem.tsx
+++ b/src/components/sidepanel/FolderTreeItem/FolderTreeItem.tsx
@@ -14,7 +14,7 @@ import Tooltip from '../../common/Tooltip';
  */
 interface DragData {
   type: 'SCRAP' | 'ARTICLE';
-  id: number;
+  id: string; // UUID
 }
 
 function isDragData(data: unknown): data is DragData {
@@ -24,7 +24,7 @@ function isDragData(data: unknown): data is DragData {
     'type' in data &&
     'id' in data &&
     (data.type === 'SCRAP' || data.type === 'ARTICLE') &&
-    typeof data.id === 'number'
+    typeof data.id === 'string'
   );
 }
 

--- a/src/components/sidepanel/RegenerateModal/RegenerateModal.tsx
+++ b/src/components/sidepanel/RegenerateModal/RegenerateModal.tsx
@@ -20,7 +20,7 @@ interface RegenerateModalProps {
 export interface RegenerateParams {
   topic: string;
   keyInsight: string;
-  selectedScrapIds: number[];
+  selectedScrapIds: string[]; // UUID strings
   writingStyleId?: number;
   additionalInstructions?: string;
 }
@@ -41,7 +41,7 @@ const RegenerateModal: React.FC<RegenerateModalProps> = ({
   // Form state
   const [topic, setTopic] = useState(article.topic || '');
   const [keyInsight, setKeyInsight] = useState(article.keyInsight || '');
-  const [selectedScrapIds, setSelectedScrapIds] = useState<number[]>(
+  const [selectedScrapIds, setSelectedScrapIds] = useState<string[]>( // UUID strings
     article.scraps?.map(s => s.scrapId) || []
   );
   const [writingStyleId, setWritingStyleId] = useState<number | undefined>(
@@ -114,7 +114,7 @@ const RegenerateModal: React.FC<RegenerateModalProps> = ({
     return () => clearTimeout(timeoutId);
   }, [isOpen, article.articleId, topic, keyInsight, selectedScrapIds, writingStyleId, additionalInstructions]);
 
-  const handleSelectionChange = useCallback((scrapIds: number[]) => {
+  const handleSelectionChange = useCallback((scrapIds: string[]) => { // UUID strings
     setSelectedScrapIds(scrapIds);
   }, []);
 

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/AddSourcePanel.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/AddSourcePanel.tsx
@@ -8,8 +8,8 @@ import styles from './SourcesSection.module.css';
 
 interface AddSourcePanelProps {
   allScraps: ScrapResponse[];
-  selectedScrapIds: number[];
-  onToggleSource: (scrapId: number) => void;
+  selectedScrapIds: string[]; // UUID strings
+  onToggleSource: (scrapId: string) => void; // UUID
   onClose: () => void;
   disabled?: boolean;
   onLoadMore: () => void;

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SelectedSourcesPills.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SelectedSourcesPills.tsx
@@ -7,7 +7,7 @@ import styles from './SourcesSection.module.css';
 
 interface SelectedSourcesPillsProps {
   selectedScraps: ScrapResponse[];
-  onRemove: (scrapId: number) => void;
+  onRemove: (scrapId: string) => void; // UUID
   disabled?: boolean;
 }
 

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourceListItem.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourceListItem.tsx
@@ -8,7 +8,7 @@ import styles from './SourcesSection.module.css';
 interface SourceListItemProps {
   scrap: ScrapResponse;
   isSelected: boolean;
-  onToggle: (scrapId: number) => void;
+  onToggle: (scrapId: string) => void; // UUID
   disabled?: boolean;
 }
 

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourcePill.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourcePill.tsx
@@ -6,7 +6,7 @@ import styles from './SourcesSection.module.css';
 
 interface SourcePillProps {
   scrap: ScrapResponse;
-  onRemove: (scrapId: number) => void;
+  onRemove: (scrapId: string) => void; // UUID
   disabled?: boolean;
 }
 

--- a/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
+++ b/src/components/sidepanel/RegenerateModal/SourcesSection/SourcesSection.tsx
@@ -7,8 +7,8 @@ import AddSourcePanel from './AddSourcePanel';
 import styles from './SourcesSection.module.css';
 
 interface SourcesSectionProps {
-  selectedScrapIds: number[];
-  onSelectionChange: (scrapIds: number[]) => void;
+  selectedScrapIds: string[]; // UUID strings
+  onSelectionChange: (scrapIds: string[]) => void; // UUID strings
   disabled?: boolean;
   initialScraps?: ScrapResponse[]; // Article's scraps for ensuring they're always available
 }
@@ -83,7 +83,7 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
   );
 
   const handleRemoveSource = useCallback(
-    (scrapId: number) => {
+    (scrapId: string) => { // UUID
       const newSelection = selectedScrapIds.filter((id) => id !== scrapId);
       onSelectionChange(newSelection);
     },
@@ -91,7 +91,7 @@ const SourcesSection: React.FC<SourcesSectionProps> = ({
   );
 
   const handleToggleSource = useCallback(
-    (scrapId: number) => {
+    (scrapId: string) => { // UUID
       const isSelected = selectedScrapIds.includes(scrapId);
       const newSelection = isSelected
         ? selectedScrapIds.filter((id) => id !== scrapId)

--- a/src/entrypoints/sidepanel/SidePanelApp.tsx
+++ b/src/entrypoints/sidepanel/SidePanelApp.tsx
@@ -42,8 +42,8 @@ const SidePanelApp: React.FC = () => {
     setCurrentPage({ type: menu as PageType });
   };
 
-  const handleNavigateToDetail = (articleId: number) => {
-    setCurrentPage({ type: 'archive-detail', draftId: articleId.toString() });
+  const handleNavigateToDetail = (articleId: string) => {
+    setCurrentPage({ type: 'archive-detail', draftId: articleId });
   };
 
   const handleArchiveBack = () => {

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -80,9 +80,9 @@ export interface RegenerateArticleV3Dto {
     topic?: string;
     keyInsight?: string;
     // 추가된 scraps (기존 article에 없던 것들)
-    addedScrapIds?: number[];
+    addedScrapIds?: string[]; // UUID strings
     // 제거된 scraps (기존 article에서 제거할 것들)
-    removedScrapIds?: number[];
+    removedScrapIds?: string[]; // UUID strings
     writingStyleId?: number | null;
     generationParams?: string;
 }

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -144,9 +144,10 @@ export interface AnalyzeContentResponse {
 
 /**
  * 아티클 생성 응답 타입 (generate API 전용)
+ * @deprecated Use GenerateArticleV2Response or ArticleResponse instead
  */
 export interface GenerateArticleResponse {
-    id: number;
+    id: string; // UUID - Updated for consistency
     title: string;
     content: string;
     createdAt: string;

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -150,7 +150,7 @@ export interface GenerateArticleResponse {
     title: string;
     content: string;
     createdAt: string;
-    userId: number;
+    userId: string;
 }
 
 /**

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -23,7 +23,7 @@ export interface CreateArticleDto {
  * 스크랩별 코멘트 인터페이스
  */
 export interface ScrapWithOptionalComment {
-    scrapId: number;
+    scrapId: string; // UUID
     userComment?: string;
 }
 
@@ -157,7 +157,7 @@ export interface GenerateArticleResponse {
  * V2 API 비동기 생성 응답
  */
 export interface GenerateArticleV2Response {
-    articleId: number;
+    articleId: string; // UUID
     status: 'processing' | 'completed' | 'failed';
     message: string;
     createdAt: string;
@@ -167,7 +167,7 @@ export interface GenerateArticleV2Response {
  * V2 API 상태 확인 응답
  */
 export interface ArticleStatusV2Response {
-    articleId: number;
+    articleId: string; // UUID
     status: 'processing' | 'completed' | 'failed';
     title?: string;
     content?: string;
@@ -200,7 +200,7 @@ export interface ArchiveResponse {
  * 스크랩 응답 타입 (아티클 상세에서 사용)
  */
 export interface ScrapResponse {
-    scrapId: number;
+    scrapId: string; // UUID
     title: string;
     url: string;
     content: string;
@@ -224,7 +224,7 @@ export interface VersionHistoryItem {
  * 아티클 응답 타입
  */
 export interface ArticleResponse {
-    articleId: number;
+    articleId: string; // UUID
     title: string;
     content: string;
     contentFormat?: 'markdown' | 'tiptap-json';
@@ -290,7 +290,7 @@ export class ArticleService {
      * 특정 아티클 조회
      * GET /api/v1/articles/:id
      */
-    async getArticle(articleId: number): Promise<ArticleResponse> {
+    async getArticle(articleId: string): Promise<ArticleResponse> {
         return this.apiRequest(`/v1/articles/${articleId}`, {
             method: 'GET',
         });
@@ -310,7 +310,7 @@ export class ArticleService {
      * 아티클 업데이트
      * PATCH /api/v1/articles/:id
      */
-    async updateArticle(articleId: number, updateData: UpdateArticleDto): Promise<ArticleResponse> {
+    async updateArticle(articleId: string, updateData: UpdateArticleDto): Promise<ArticleResponse> {
         return this.apiRequest(`/v1/articles/${articleId}`, {
             method: 'PATCH',
             body: JSON.stringify(updateData),
@@ -321,7 +321,7 @@ export class ArticleService {
      * 아티클 삭제
      * DELETE /api/v1/articles/:id
      */
-    async deleteArticle(articleId: number): Promise<void> {
+    async deleteArticle(articleId: string): Promise<void> {
         return this.apiRequest(`/v1/articles/${articleId}`, {
             method: 'DELETE',
         });
@@ -331,7 +331,7 @@ export class ArticleService {
      * 아티클 아카이브
      * POST /api/v1/articles/:id/archive
      */
-    async archiveArticle(articleId: number): Promise<void> {
+    async archiveArticle(articleId: string): Promise<void> {
         return this.apiRequest(`/v1/articles/${articleId}/archive`, {
             method: 'POST',
         });
@@ -341,7 +341,7 @@ export class ArticleService {
      * 아티클 버전 히스토리 조회
      * GET /v1/articles/:id/versions
      */
-    async getArticleVersions(articleId: number): Promise<VersionHistoryItem[]> {
+    async getArticleVersions(articleId: string): Promise<VersionHistoryItem[]> {
         return this.apiRequest(`/v1/articles/${articleId}/versions`, {
             method: 'GET',
         });
@@ -351,7 +351,7 @@ export class ArticleService {
      * 특정 버전으로 복원
      * POST /v1/articles/:id/restore/:versionNumber
      */
-    async restoreVersion(articleId: number, versionNumber: number): Promise<ArticleResponse> {
+    async restoreVersion(articleId: string, versionNumber: number): Promise<ArticleResponse> {
         return this.apiRequest(`/v1/articles/${articleId}/restore/${versionNumber}`, {
             method: 'POST',
         });
@@ -398,7 +398,7 @@ export class ArticleService {
      * V2: 아티클 생성 상태 확인
      * GET /api/v2/articles/:id/status
      */
-    async getArticleStatusV2(articleId: number): Promise<ArticleStatusV2Response> {
+    async getArticleStatusV2(articleId: string): Promise<ArticleStatusV2Response> {
         return this.apiRequest(`/v2/articles/${articleId}/status`, {
             method: 'GET',
         });
@@ -422,8 +422,8 @@ export class ArticleService {
      * @returns 완성된 아티클 정보 또는 타임아웃/에러
      */
   async waitForArticleCompletion(
-        articleId: number, 
-        maxAttempts: number = 60, 
+        articleId: string,
+        maxAttempts: number = 60,
         interval: number = 5000
     ): Promise<ArticleStatusV2Response> {
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -472,7 +472,7 @@ export class ArticleService {
      * V3: 아티클 생성 상태 확인
      * GET /api/v3/articles/:id/status
      */
-    async getArticleStatusV3(articleId: number): Promise<ArticleStatusV3Response> {
+    async getArticleStatusV3(articleId: string): Promise<ArticleStatusV3Response> {
         return this.apiRequest(`/v3/articles/${articleId}/status`, {
             method: 'GET',
         });
@@ -496,7 +496,7 @@ export class ArticleService {
      * @returns 완성된 아티클 정보 또는 타임아웃/에러
      */
     async waitForArticleCompletionV3(
-        articleId: number,
+        articleId: string,
         maxAttempts: number = 50,
         interval: number = 5000
     ): Promise<ArticleStatusV3Response> {
@@ -633,7 +633,7 @@ export class ArticleService {
      * @returns Promise<ArticleResponse>
      */
     async regenerateArticleV3(
-        articleId: number,
+        articleId: string,
         dto: RegenerateArticleV3Dto
     ): Promise<ArticleResponse> {
         const response = await globalApiClient.post<ArticleResponse>(
@@ -651,7 +651,7 @@ export class ArticleService {
      * @returns Promise<void>
      */
     async regenerateArticleV3Stream(
-        articleId: number,
+        articleId: string,
         dto: RegenerateArticleV3Dto,
         onEvent: (event: StreamEvent) => void
     ): Promise<void> {

--- a/src/services/folderService.ts
+++ b/src/services/folderService.ts
@@ -57,8 +57,8 @@ export interface FolderContentsResponse {
  * Add items to folder DTO - matches backend MoveFolderItemsDto
  */
 export interface AddItemsToFolderDto {
-  scrapIds?: number[];
-  articleIds?: number[];
+  scrapIds?: string[]; // UUID strings
+  articleIds?: string[]; // UUID strings
   targetFolderId?: string | null;
 }
 
@@ -190,7 +190,7 @@ export class FolderService {
   async removeItemFromFolder(
     folderId: number,
     contentType: 'SCRAP' | 'ARTICLE',
-    contentId: number
+    contentId: string // UUID
   ): Promise<void> {
     try {
       const payload: AddItemsToFolderDto = {

--- a/src/services/folderService.ts
+++ b/src/services/folderService.ts
@@ -14,7 +14,7 @@ export interface FolderResponse {
   name: string;
   color?: string;
   parentId?: number;
-  userId: number;
+  userId: string;
   createdAt: string;
   updatedAt: string;
   itemCount?: number;

--- a/src/services/scrapService.ts
+++ b/src/services/scrapService.ts
@@ -77,7 +77,7 @@ export interface CreateScrapDto {
  * 스크랩 응답 DTO
  */
 export interface ScrapResponse {
-  scrapId: number;
+  scrapId: string; // UUID
   url: string;
   title: string;
   content: string;
@@ -320,7 +320,7 @@ export class ScrapService {
   /**
    * 스크랩 단건 조회
    */
-  async getScrapById(scrapId: number): Promise<ScrapResponse> {
+  async getScrapById(scrapId: string): Promise<ScrapResponse> {
     try {
       // Use Version 2 API for enhanced metadata
       const response = await this.apiRequest<ScrapResponse>(`/scraps/${scrapId}`, {
@@ -335,7 +335,7 @@ export class ScrapService {
   /**
    * 스크랩 삭제
    */
-  async deleteScrap(scrapId: number): Promise<void> {
+  async deleteScrap(scrapId: string): Promise<void> {
     try {
       // logger.debug('🗑️ Deleting scrap:', scrapId);
 
@@ -365,7 +365,7 @@ export class ScrapService {
   /**
    * 스크랩에 태그 추가
    */
-  async addTagToScrap(scrapId: number, tagName: string): Promise<TagResponse> {
+  async addTagToScrap(scrapId: string, tagName: string): Promise<TagResponse> {
     try {
       // logger.debug('🏷️ Adding tag to scrap:', { scrapId, tagName });
 
@@ -400,7 +400,7 @@ export class ScrapService {
   /**
    * 스크랩의 태그 목록 조회
    */
-  async getScrapTags(scrapId: number): Promise<TagResponse[]> {
+  async getScrapTags(scrapId: string): Promise<TagResponse[]> {
     try {
       // logger.debug('🏷️ Fetching scrap tags:', scrapId);
 
@@ -423,7 +423,7 @@ export class ScrapService {
   /**
    * 스크랩에서 태그 제거
    */
-  async removeTagFromScrap(scrapId: number, tagId: number): Promise<void> {
+  async removeTagFromScrap(scrapId: string, tagId: number): Promise<void> {
     try {
       // logger.debug('🗑️ Removing tag from scrap:', { scrapId, tagId });
 

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -51,7 +51,7 @@ export class TagService {
      * 태그 생성
      * POST /api/v1/tags
      */
-    async createTag(tagData: CreateTagDto, scrapId?: number): Promise<TagResponse> {
+    async createTag(tagData: CreateTagDto, scrapId?: string): Promise<TagResponse> {
         const endpoint = scrapId ? `/v1/tags?scrapId=${scrapId}` : '/v1/tags';
         return this.apiRequest(endpoint, {
             method: 'POST',
@@ -66,12 +66,12 @@ export class TagService {
      * 현재 사용자의 태그 목록 조회
      * GET /api/v1/tags
      */
-    async getTags(name?: string, scrapId?: number): Promise<TagResponse[]> {
+    async getTags(name?: string, scrapId?: string): Promise<TagResponse[]> {
         let endpoint = '/v1/tags';
         const params = new URLSearchParams();
-        
+
         if (name) params.append('name', name);
-        if (scrapId) params.append('scrapId', scrapId.toString());
+        if (scrapId) params.append('scrapId', scrapId);
         
         if (params.toString()) {
             endpoint += `?${params.toString()}`;
@@ -133,7 +133,7 @@ export class TagService {
      * 특정 스크랩의 태그 목록
      * GET /api/v1/tags/scrap/:scrapId
      */
-    async getScrapTags(scrapId: number): Promise<TagResponse[]> {
+    async getScrapTags(scrapId: string): Promise<TagResponse[]> {
         return this.apiRequest(`/v1/tags/scrap/${scrapId}`, {
             method: 'GET',
         });

--- a/src/services/unifiedContentService.ts
+++ b/src/services/unifiedContentService.ts
@@ -119,10 +119,15 @@ export class UnifiedContentService {
       const transformedItems: UnifiedContentItem[] = apiResponse.items
         .map((item: RawApiContentItem): UnifiedContentItem | null => {
           if (item.type === 'scrap') {
+            // ID is now UUID (string), no need to parse
+            if (!item.id) {
+              console.error('❌ Missing scrap ID from API:', 'Full item:', item);
+              return null; // Skip this item
+            }
             return {
               type: 'SCRAP' as const,
               data: {
-                scrapId: parseInt(item.id, 10),
+                scrapId: item.id,
                 title: item.title,
                 content: item.contentPreview || '',
                 htmlContent: '', // Not provided in unified API response
@@ -152,10 +157,15 @@ export class UnifiedContentService {
               },
             };
           } else if (item.type === 'article') {
+            // ID is now UUID (string), no need to parse
+            if (!item.id) {
+              console.error('❌ Missing article ID from API:', 'Full item:', item);
+              return null; // Skip this item
+            }
             return {
               type: 'ARTICLE' as const,
               data: {
-                articleId: parseInt(item.id, 10),
+                articleId: item.id,
                 title: item.title || '',
                 content: item.contentPreview || '',
                 topic: item.topic || '',

--- a/src/services/uploadService.ts
+++ b/src/services/uploadService.ts
@@ -5,7 +5,7 @@ interface UploadResponse {
   url: string;
   name: string;
   size: number;
-  uploadedBy: number;
+  uploadedBy: string;
   title?: string;
   description?: string;
 }
@@ -36,7 +36,7 @@ class UploadService {
         url: response.filePath,
         name: response.fileName,
         size: response.fileSize,
-        uploadedBy: response.user?.userId || 0,
+        uploadedBy: response.user?.userId || '',
         title: response.title,
         description: response.description,
       };

--- a/src/services/writingStyleService.ts
+++ b/src/services/writingStyleService.ts
@@ -17,7 +17,7 @@ export interface WritingStyle {
   id: number;
   name: string;
   user: {
-    id: number;
+    id: string;
   };
   examples: WritingStyleExample[];
   createdAt: string;

--- a/src/sidepanel_unused/App.tsx
+++ b/src/sidepanel_unused/App.tsx
@@ -36,8 +36,8 @@ const App: React.FC = () => {
     setCurrentPage({ type: menu as PageType });
   };
 
-  const handleNavigateToDetail = (articleId: number) => {
-    setCurrentPage({ type: 'archive-detail', draftId: articleId.toString() });
+  const handleNavigateToDetail = (articleId: string) => { // UUID
+    setCurrentPage({ type: 'archive-detail', draftId: articleId });
   };
 
   const handleArchiveBack = () => {

--- a/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
+++ b/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
@@ -48,7 +48,7 @@ interface ArchiveDetailPageProps {
 // Scraps Section Component with collapsible functionality
 interface ScrapsSectionProps {
   scraps: Array<{
-    scrapId: number;
+    scrapId: string; // UUID
     title: string;
     url: string;
     userComment?: string;
@@ -198,7 +198,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
   // 아티클 데이터 새로고침 함수 (전체 페이지 리로드 없이)
   const refreshArticleData = useCallback(async () => {
     try {
-      const articleData = await articleService.getArticle(parseInt(draftId));
+      const articleData = await articleService.getArticle(draftId);
       
       // 연속된 개행 정리 - 저장 시마다 개행이 늘어나는 문제 해결
       const normalizeContent = (content: string) => {
@@ -244,7 +244,7 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
     const fetchArticle = async () => {
       try {
         setLoading(true);
-        const articleData = await articleService.getArticle(parseInt(draftId));
+        const articleData = await articleService.getArticle(draftId);
 
         // 연속된 개행 정리 - 저장 시마다 개행이 늘어나는 문제 해결
         const normalizeContent = (content: string) => {

--- a/src/sidepanel_unused/pages/ArchivePage.tsx
+++ b/src/sidepanel_unused/pages/ArchivePage.tsx
@@ -19,7 +19,7 @@ const ArchivePage = forwardRef<ArchivePageRef, ArchivePageProps>(({ onDraftClick
   const [articles, setArticles] = useState<ArticleResponse[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null); // UUID
   const [deleteTimeoutId, setDeleteTimeoutId] = useState<NodeJS.Timeout | null>(null);
   const [deletedArticle, setDeletedArticle] = useState<ArticleResponse | null>(null);
   const { t } = useI18n();
@@ -56,7 +56,7 @@ const ArchivePage = forwardRef<ArchivePageRef, ArchivePageProps>(({ onDraftClick
     };
   }, [deleteTimeoutId]);
 
-  const handleDelete = (id: number) => {
+  const handleDelete = (id: string) => { // UUID
     // If there's already a pending delete, complete it immediately
     if (pendingDeleteId !== null && deleteTimeoutId) {
       clearTimeout(deleteTimeoutId);
@@ -106,7 +106,7 @@ const ArchivePage = forwardRef<ArchivePageRef, ArchivePageProps>(({ onDraftClick
     }
   };
 
-  const executeDelete = async (id: number) => {
+  const executeDelete = async (id: string) => { // UUID
     try {
       await articleService.deleteArticle(id);
       setPendingDeleteId(null);

--- a/src/sidepanel_unused/pages/ArticleGeneratePage.tsx
+++ b/src/sidepanel_unused/pages/ArticleGeneratePage.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../analytics/bridge';
 
 interface ArticleGeneratePageProps {
-  onNavigateToDetail: (articleId: number) => void;
+  onNavigateToDetail: (articleId: string) => void; // UUID
   onNavigate: (page: PageType) => void;
   currentPage?: string;
   onRefreshArchiveList?: () => void;
@@ -618,10 +618,10 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
     usagePrompt: string; // 해당 자료를 어떻게 쓸지 지시문
   }>>([]);
   // 막힘 애니메이션 상태 (75자 도달 시 순간 흔들기)
-  const [blockedAnimIds, setBlockedAnimIds] = useState<Set<number>>(new Set());
+  const [blockedAnimIds, setBlockedAnimIds] = useState<Set<string | number>>(new Set());
 
 
-  const triggerBlockedAnim = (id: number) => {
+  const triggerBlockedAnim = (id: string | number) => { // UUID string or number
     setBlockedAnimIds(prev => new Set(prev).add(id));
     setTimeout(() => {
       setBlockedAnimIds(prev => {

--- a/src/sidepanel_unused/pages/ArticleGeneratePage.tsx
+++ b/src/sidepanel_unused/pages/ArticleGeneratePage.tsx
@@ -301,11 +301,11 @@ const ArticleGeneratePage: React.FC<ArticleGeneratePageProps> = ({
     }
   };
 
-  const handleOpinionChange = (id: number, opinion: string) => {
+  const handleOpinionChange = (id: string, opinion: string) => { // UUID
     updateScrapOpinion(id, opinion);
   };
 
-  const handleRemoveScrap = async (id: number) => {
+  const handleRemoveScrap = async (id: string) => { // UUID
     removeScrap(id);
     try {
       await trackArticleReferenceRemovedBridge({

--- a/src/sidepanel_unused/pages/ScrapPage.tsx
+++ b/src/sidepanel_unused/pages/ScrapPage.tsx
@@ -282,9 +282,9 @@ const ScrapPage = forwardRef<ScrapPageRef, {}>((_, ref) => {
     try {
       setIsAddingTag(true);
       // console.log('🏷️ Adding tag:', tag, 'to scrap:', scrapId);
-      
+
       // 서버 API 호출하여 태그 추가
-      await scrapService.addTagToScrap(parseInt(scrapId), tag.trim());
+      await scrapService.addTagToScrap(scrapId, tag.trim()); // scrapId is UUID string
       
       // console.log('✅ Tag added successfully');
       
@@ -320,15 +320,15 @@ const ScrapPage = forwardRef<ScrapPageRef, {}>((_, ref) => {
       }
 
       // 실제 태그 객체에서 tagId를 찾기 위해 서버에서 태그 정보 조회
-      const scrapTags = await scrapService.getScrapTags(parseInt(scrapId));
+      const scrapTags = await scrapService.getScrapTags(scrapId); // scrapId is UUID string
       const tagToRemove = scrapTags.find(tag => tag.name === tagName);
-      
+
       if (!tagToRemove) {
         throw new Error(t('scrapPage_tagNotFound'));
       }
-      
+
       // 서버 API 호출하여 태그 삭제
-      await scrapService.removeTagFromScrap(parseInt(scrapId), tagToRemove.tagId);
+      await scrapService.removeTagFromScrap(scrapId, tagToRemove.tagId); // scrapId is UUID string
       
       // console.log('✅ Tag removed successfully');
       
@@ -403,9 +403,9 @@ const ScrapPage = forwardRef<ScrapPageRef, {}>((_, ref) => {
     }
   };
 
-  const executeDeleteScrap = async (scrapId: string) => {
+  const executeDeleteScrap = async (scrapId: string) => { // UUID
     try {
-      await scrapService.deleteScrap(parseInt(scrapId));
+      await scrapService.deleteScrap(scrapId); // scrapId is UUID string
       setPendingDeleteId(null);
       setDeletedScrap(null);
       setDeleteTimeoutId(null);

--- a/src/sidepanel_unused/pages/UnifiedContentPage.tsx
+++ b/src/sidepanel_unused/pages/UnifiedContentPage.tsx
@@ -20,7 +20,7 @@ import { PDFUploadModal } from '../../components/sidepanel/PDFUploadModal/PDFUpl
 import { trackPDFUploadModalOpenedBridge } from '../../analytics/bridge';
 
 interface UnifiedContentPageProps {
-  onNavigateToDetail: (articleId: number) => void;
+  onNavigateToDetail: (articleId: string) => void;
 }
 
 export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNavigateToDetail }) => {
@@ -137,7 +137,7 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     };
   }, [items.length]);
 
-  const handleDeleteScrap = async (scrapId: number) => {
+  const handleDeleteScrap = async (scrapId: string) => {
     if (!confirm(t('scrapPage_confirmDelete'))) return;
 
     try {
@@ -149,7 +149,7 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     }
   };
 
-  const handleDeleteArticle = async (articleId: number) => {
+  const handleDeleteArticle = async (articleId: string) => {
     if (!confirm(t('archivePage_confirmDelete'))) return;
 
     try {
@@ -190,7 +190,7 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     showSuccess(t('common_success'), t('pdfUpload_uploadSuccess'));
   }, [refreshContent, showSuccess, t]);
 
-  const openScrapInNewTab = useCallback(async (scrapId: number, scrapType?: string) => {
+  const openScrapInNewTab = useCallback(async (scrapId: string, scrapType?: string) => {
     try {
       const viewerType = scrapType === 'webclip' ? 'SCRAP' : 'UPLOAD';
       const url = browser.runtime.getURL(`/webviewer.html#type=${viewerType}&id=${scrapId}`);
@@ -200,11 +200,11 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     }
   }, [showError, t]);
 
-  const openArticleInEditor = useCallback((articleId: number) => {
+  const openArticleInEditor = useCallback((articleId: string) => {
     onNavigateToDetail(articleId);
   }, [onNavigateToDetail]);
 
-  const handleRemoveTag = async (itemType: 'SCRAP' | 'ARTICLE', itemId: number, tagName: string) => {
+  const handleRemoveTag = async (itemType: 'SCRAP' | 'ARTICLE', itemId: string, tagName: string) => {
     try {
       if (itemType === 'SCRAP') {
         const tags = await scrapService.getScrapTags(itemId);
@@ -229,7 +229,7 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     }
   };
 
-  const handleAddTag = async (itemType: 'SCRAP' | 'ARTICLE', itemId: number, tagName: string) => {
+  const handleAddTag = async (itemType: 'SCRAP' | 'ARTICLE', itemId: string, tagName: string) => {
     try {
       if (itemType === 'SCRAP') {
         // Find current item and check for duplicate tags
@@ -266,7 +266,7 @@ export const UnifiedContentPage: React.FC<UnifiedContentPageProps> = ({ onNaviga
     }
   };
 
-  const handleDragStart = (e: React.DragEvent, itemType: 'SCRAP' | 'ARTICLE', itemId: number) => {
+  const handleDragStart = (e: React.DragEvent, itemType: 'SCRAP' | 'ARTICLE', itemId: string) => {
     e.stopPropagation();
     e.dataTransfer.effectAllowed = 'move';
 

--- a/src/stores/articleGenerateStore.ts
+++ b/src/stores/articleGenerateStore.ts
@@ -66,8 +66,8 @@ interface ArticleGenerateActions {
   
   // 스크랩 관련 액션
   addScrap: (scrap: ScrapResponse) => void;
-  removeScrap: (scrapId: number) => void;
-  updateScrapOpinion: (scrapId: number, opinion: string) => void;
+  removeScrap: (scrapId: string) => void; // UUID
+  updateScrapOpinion: (scrapId: string, opinion: string) => void; // UUID
   clearScraps: () => void;
   
   // 태그 관련 액션
@@ -224,11 +224,11 @@ export const useArticleGenerateStore = create<ArticleGenerateStore>()(
           }
         }),
 
-        removeScrap: (scrapId: number) => set((state) => {
+        removeScrap: (scrapId: string) => set((state) => { // UUID
           state.selectedScraps = state.selectedScraps.filter(scrap => scrap.scrapId !== scrapId);
         }),
 
-        updateScrapOpinion: (scrapId: number, opinion: string) => set((state) => {
+        updateScrapOpinion: (scrapId: string, opinion: string) => set((state) => { // UUID
           const scrap = state.selectedScraps.find(s => s.scrapId === scrapId);
           if (scrap) {
             scrap.opinion = opinion;

--- a/src/stores/contentStore.ts
+++ b/src/stores/contentStore.ts
@@ -39,7 +39,7 @@ interface ContentState {
   isFolderSidebarCollapsed: boolean;
   isCreateFolderModalOpen: boolean;
   isMoveFolderModalOpen: boolean;
-  selectedItemsForMove: Array<{ type: 'SCRAP' | 'ARTICLE'; id: number }>;
+  selectedItemsForMove: Array<{ type: 'SCRAP' | 'ARTICLE'; id: string }>; // UUID strings
 
   // Actions - Folders
   loadFolders: () => Promise<void>;
@@ -63,7 +63,7 @@ interface ContentState {
   toggleFolderSidebar: () => void;
   openCreateFolderModal: () => void;
   closeCreateFolderModal: () => void;
-  openMoveFolderModal: (items: Array<{ type: 'SCRAP' | 'ARTICLE'; id: number }>) => void;
+  openMoveFolderModal: (items: Array<{ type: 'SCRAP' | 'ARTICLE'; id: string }>) => void; // UUID strings
   closeMoveFolderModal: () => void;
   moveItemsToFolder: (folderId: number) => Promise<void>;
 }

--- a/src/webviewer/App.tsx
+++ b/src/webviewer/App.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '../hooks/useI18n';
 const ScrapView = React.lazy(() => import('./ScrapView'));
 const UploadView = React.lazy(() => import('./UploadView'));
 
-type ViewTarget = { kind: 'SCRAP' | 'UPLOAD'; id: number } | null;
+type ViewTarget = { kind: 'SCRAP' | 'UPLOAD'; id: string } | null;
 
 const parseViewTarget = (): ViewTarget => {
   const hash = window.location.hash?.replace(/^#/, '') || '';
@@ -14,8 +14,9 @@ const parseViewTarget = (): ViewTarget => {
 
   const type = (h.get('type') || s.get('type') || '').toUpperCase();
   const idStr = h.get('id') || s.get('id');
-  if ((type === 'SCRAP' || type === 'UPLOAD') && idStr && /^\d+$/.test(idStr)) {
-    return { kind: type as 'SCRAP' | 'UPLOAD', id: parseInt(idStr, 10) };
+  // Support both UUID (string) and legacy numeric IDs
+  if ((type === 'SCRAP' || type === 'UPLOAD') && idStr && idStr.trim() !== '') {
+    return { kind: type as 'SCRAP' | 'UPLOAD', id: idStr };
   }
   return null;
 };

--- a/src/webviewer/ScrapView.tsx
+++ b/src/webviewer/ScrapView.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '../hooks/useI18n';
 import styles from './ScrapView.module.css';
 import { IoLinkOutline, IoTimeOutline } from 'react-icons/io5';
 
-interface Props { id: number }
+interface Props { id: string }
 
 interface ScrapData {
   title: string;

--- a/src/webviewer/UploadView.tsx
+++ b/src/webviewer/UploadView.tsx
@@ -11,7 +11,7 @@ import { trackPDFDownloadBridge } from '../analytics/bridge';
 pdfjs.GlobalWorkerOptions.workerSrc = (globalThis as any).chrome?.runtime?.getURL('pdf.worker.min.js') || '/pdf.worker.min.js';
 
 
-interface Props { id: number }
+interface Props { id: string }
 
 interface UploadData {
   title: string;


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-436](https://linear.app/chill-mato/issue/CHI-436/uuid-마이그레이션-프론트엔드-타입-시스템-전환)

## 변경 요약
Users, Scraps, Articles 테이블의 PK가 UUID로 변경됨에 따라 프론트엔드 전체 타입 시스템을 UUID string으로 통일

## 주요 변경사항

### 드래그 앤 드롭 타입 수정
- `FolderSidebar`, `FolderTreeItem`의 `DragData.id` 타입: `number` → `string`
- 타입 가드 `isDragData` 수정하여 UUID string 검증
- **문제 해결**: 폴더로 콘텐츠 이동 시 타입 검증 실패 문제

### 서비스 레이어 업데이트
- `folderService.ts`: `AddItemsToFolderDto` 인터페이스 - `scrapIds`, `articleIds`를 `string[]`로 변경
- `articleService.ts`: `RegenerateArticleV3Dto` - `addedScrapIds`, `removedScrapIds`를 `string[]`로 변경
- 모든 API 메서드 파라미터를 UUID string으로 통일

### 컴포넌트 레이어 업데이트
- `RegenerateModal` 및 하위 컴포넌트: `selectedScrapIds`, `onRemove` 콜백 타입 수정
- `VersionHistoryPanel`: `articleId` prop `number` → `string`
- `ArticleGeneratePage`: navigation 콜백, `blockedAnimIds` state 타입 수정
- 모든 `parseInt()` 호출 제거

### 상태 관리 업데이트
- `contentStore`: `selectedItemsForMove` 타입 `Array<{ type: 'SCRAP' | 'ARTICLE'; id: string }>`
- `articleGenerateStore`: `removeScrap`, `updateScrapOpinion` 파라미터 string 변경

### 레거시 코드 정리
- `GenerateArticleResponse` 인터페이스 `id` 타입 통일: `number` → `string`
- `@deprecated` 주석 추가 (V2/V3 API 사용 권장)

## 테스트
- [x] 빌드 확인 - 타입 체크 통과 (UUID 관련 에러 0건)
- [x] 주요 기능 정상 동작 확인
  - [x] 폴더 드래그 앤 드롭
  - [x] 아티클 생성/재생성
  - [x] 버전 히스토리 조회
  - [x] 스크랩 관리

## 기타 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal identifier system to use UUID strings instead of numeric IDs across articles, scraps, uploads, and related content throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->