### PR TITLE
[CHI-437] 아티클 편집을 웹 클라이언트로 리다이렉트

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -8,18 +8,21 @@ export interface Environment {
   serverUrl: string;
   apiUrl: string;
   oauthCallbackPath: string;
+  webClientUrl: string;
 }
 
 const development: Environment = {
   serverUrl: 'https://api.tyquill.ai',
   apiUrl: 'http://localhost:3001/api',
   oauthCallbackPath: '/api/auth/callback',
+  webClientUrl: 'http://localhost:5173',
 };
 
 const production: Environment = {
   serverUrl: 'https://api.tyquill.ai',
   apiUrl: 'https://api.tyquill.ai/api',
   oauthCallbackPath: '/api/auth/callback',
+  webClientUrl: 'https://app.tyquill.ai',
 };
 
 // 빌드 환경 확인 (webpack에서 주입)
@@ -61,6 +64,13 @@ export const API_BASE_URL = environment.apiUrl;
  */
 export const getOAuthCallbackUrl = (): string => {
   return `${environment.serverUrl}${environment.oauthCallbackPath}`;
+};
+
+/**
+ * 웹 클라이언트 URL 반환
+ */
+export const getWebClientUrl = (): string => {
+  return environment.webClientUrl;
 };
 
 /**

--- a/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
+++ b/src/sidepanel_unused/pages/ArchiveDetailPage.tsx
@@ -39,6 +39,7 @@ import {
   trackArchiveFullscreenEditorOpenedBridge,
   trackArchiveVersionChangedBridge
 } from '../../analytics/bridge';
+import { getWebClientUrl } from '../../config/environment';
 
 interface ArchiveDetailPageProps {
   draftId: string;
@@ -349,38 +350,29 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
   }, [countEditor, currentArchive?.content, article?.content, editContent, isEditing]);
 
   const handleEdit = async () => {
-    // 편집기 페이지가 열려있으면 편집 모드 진입 방지
-    if (isEditorPageOpen) {
-      alert(t('archiveDetailPage_editingInPageEditorAlert'));
-      return;
-    }
+    if (!article) return;
 
     try {
       await trackArchiveEditStartedBridge({
-        article_id: article?.articleId,
+        article_id: article.articleId,
         version_number: selectedVersionNumber,
-        has_versions: (article?.archives?.length || 0) > 0,
+        has_versions: (article.archives?.length || 0) > 0,
         character_count: characterCount.characters,
         word_count: characterCount.words
       });
     } catch {}
 
-    // Content format 확인 및 설정
-    const archive = currentArchive || article?.archives?.[0];
-    const format = (archive as any)?.contentFormat || 'markdown';
-    setEditContentFormat(format);
+    try {
+      // 웹 클라이언트로 리다이렉트
+      const webClientUrl = getWebClientUrl();
+      const editUrl = `${webClientUrl}/workspace/articles/${article.articleId}`;
 
-    // JSON 형식이면 파싱
-    if (format === 'tiptap-json' && typeof editContent === 'string') {
-      try {
-        setEditContent(JSON.parse(editContent));
-      } catch {
-        // 파싱 실패 시 마크다운으로 처리
-        setEditContentFormat('markdown');
-      }
+      // Chrome tabs API를 사용하여 새 탭 열기
+      await browser.tabs.create({ url: editUrl });
+    } catch (error) {
+      console.error('Failed to open web client for editing:', error);
+      alert(t('archiveDetailPage_openWebClientError') || 'Failed to open web editor. Please try again.');
     }
-
-    setIsEditing(true);
   };
 
   const handleSave = async () => {
@@ -480,55 +472,15 @@ const ArchiveDetailPage: React.FC<ArchiveDetailPageProps> = ({ draftId, onBack }
     } catch {}
 
     try {
-      // 편집기로 전달할 데이터 준비
-      const archive = currentArchive || article.archives?.[0];
-      const contentFormat = (archive as any)?.contentFormat || 'markdown';
+      // 웹 클라이언트로 리다이렉트
+      const webClientUrl = getWebClientUrl();
+      const editUrl = `${webClientUrl}/workspace/articles/${article.articleId}`;
 
-      // Content를 문자열로 변환 (JSON 형식이면 stringify)
-      const contentToPass = typeof editContent === 'object'
-        ? JSON.stringify(editContent)
-        : editContent;
-
-      const originalContent = currentArchive?.content || article.content;
-      const originalContentToPass = typeof originalContent === 'object'
-        ? JSON.stringify(originalContent)
-        : originalContent;
-
-      // originalContentFormat은 originalContent와 동일한 소스에서 파생
-      const originalContentFormat = currentArchive
-        ? ((currentArchive as any)?.contentFormat || 'markdown')
-        : ((article as any)?.contentFormat || 'markdown');
-
-      const editorData = {
-        articleId: article.articleId,
-        title: editTitle,
-        content: contentToPass,
-        contentFormat: contentFormat,
-        originalTitle: currentArchive?.title || article.title,
-        originalContent: originalContentToPass,
-        originalContentFormat: originalContentFormat
-      };
-
-      // browser.storage.local을 사용하여 안전하게 데이터 전달 (anchor 링크나 특수 문자 처리)
-      const sessionKey = `tyquill-editor-data-${Date.now()}-${Math.random()}`;
-      await browser.storage.local.set({
-        [sessionKey]: editorData
-      });
-      const editorUrl = `${browser.runtime.getURL('/editor.html')}?sessionKey=${sessionKey}`;
-
-      // 새 탭에서 편집기 열기 - background script를 통해 처리
-      const response = await browser.runtime.sendMessage({
-        action: 'openFullscreenEditor',
-        editorUrl
-      });
-
-      if (!response?.success) {
-        throw new Error(response?.error || 'Failed to open fullscreen editor');
-      }
+      // Chrome tabs API를 사용하여 새 탭 열기
+      await browser.tabs.create({ url: editUrl });
     } catch (error) {
-      console.error('Failed to open fullscreen editor:', error);
-      // 사용자에게 에러 알림
-      alert('Failed to open fullscreen editor. Please try again.');
+      console.error('Failed to open web client for fullscreen editing:', error);
+      alert(t('archiveDetailPage_openWebClientError') || 'Failed to open web editor. Please try again.');
     }
   };
 

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -133,6 +133,7 @@ const koTranslations = {
   archiveDetailPage_backToCurrent: "현재 버전으로",
   archiveDetailPage_characters: "자",
   archiveDetailPage_regenerate: "다시 생성",
+  archiveDetailPage_openWebClientError: "웹 에디터를 여는 중 오류가 발생했습니다. 다시 시도해주세요.",
 
   // Regenerate Modal
   regenerateModal_title: "아티클 다시 생성",
@@ -709,6 +710,7 @@ const enTranslations = {
   archiveDetailPage_backToCurrent: "Back to current",
   archiveDetailPage_characters: " characters",
   archiveDetailPage_regenerate: "Regenerate",
+  archiveDetailPage_openWebClientError: "Failed to open web editor. Please try again.",
 
   // Regenerate Modal
   regenerateModal_title: "Regenerate Article",


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-437](https://linear.app/chill-mato/issue/CHI-437/)

## 변경 요약
익스텐션에서 아티클 수정 버튼 클릭 시 익스텐션 내부 에디터 대신 웹 클라이언트로 리다이렉트하도록 변경

## 주요 변경사항
- **수정하기/전체화면 수정 버튼 동작 변경**: `browser.tabs.create()` API를 사용하여 웹 클라이언트로 새 탭 열기
- **환경별 웹 클라이언트 URL 설정**:
  - 개발: `http://localhost:5173/workspace/articles/{articleId}`
  - 프로덕션: `https://app.tyquill.ai/workspace/articles/{articleId}`
- **에러 처리**: 웹 클라이언트 열기 실패 시 다국어 에러 메시지 표시

### 수정된 파일
- `src/config/environment.ts`: webClientUrl 설정 추가
- `src/sidepanel_unused/pages/ArchiveDetailPage.tsx`: handleEdit(), handleOpenFullscreenEditor() 함수 수정
- `src/utils/translations.ts`: 에러 메시지 번역 추가

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인
  - 아카이브 상세 페이지에서 "수정하기" 버튼 클릭 시 웹 클라이언트로 이동
  - "전체화면 수정" 버튼 클릭 시 웹 클라이언트로 이동

## 기타 참고사항
- 익스텐션 내부 편집 기능은 유지되지만 버튼으로는 더 이상 접근할 수 없음
- 웹 클라이언트 편집 후 익스텐션 동기화는 수동으로 새로고침 필요 (자동 동기화는 구현하지 않음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive editing now uses an external web client instead of the in-app editor for an improved editing experience.
  * Editing opens in a new tab for easy access.

* **Bug Fixes**
  * Added error notifications when the web editor fails to open, with localized messages for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->