### PR TITLE
[CHI-438] 언어 변경 시 백엔드 API 동기화

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -671,6 +671,32 @@ class AuthService {
   }
 
   /**
+   * 사용자 언어 설정 업데이트
+   */
+  async updateLanguage(language: string): Promise<void> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.API_URL}/auth/profile/language`, {
+        method: 'PATCH',
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ language }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update language preference');
+      }
+
+      // logger.debug('✅ Language preference updated:', language);
+    } catch (error) {
+      // console.error('❌ Failed to update language:', error);
+      throw error;
+    }
+  }
+
+  /**
    * 상태 변경 리스너들
    */
   private listeners: Array<(state: AuthState) => void> = [];

--- a/src/stores/languageStore.ts
+++ b/src/stores/languageStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { browser } from 'wxt/browser';
+import { authService } from '../services/auth.service';
 
 export type SupportedLanguage = 'ko' | 'en';
 
@@ -17,6 +18,19 @@ export const useLanguageStore = create<LanguageState>()((set, get) => ({
     // Chrome storage에 저장
     await browser.storage.sync.set({ 'tyquill-language-preference': language });
     set({ selectedLanguage: language });
+
+    // 백엔드 API에 언어 설정 동기화
+    if (language) {
+      try {
+        const authState = authService.getAuthState();
+        if (authState.isAuthenticated) {
+          await authService.updateLanguage(language);
+        }
+      } catch (error) {
+        console.warn('Failed to sync language preference to server:', error);
+        // 서버 동기화 실패해도 로컬 변경은 유지
+      }
+    }
   },
 
   getCurrentLanguage: () => {


### PR DESCRIPTION
## 🔗 연관 이슈
Closes: [CHI-438](https://linear.app/chill-mato/issue/CHI-438/)

## 변경 요약
익스텐션에서 언어 변경 시 백엔드 API를 자동으로 호출하여 사용자 언어 설정을 서버에 동기화

## 주요 변경사항
- **AuthService에 언어 업데이트 메서드 추가**:
  - `updateLanguage(language: string)` 메서드 구현
  - `PATCH /auth/profile/language` 엔드포인트 호출
  - JWT 인증 헤더 자동 포함

- **LanguageStore 언어 변경 로직 개선**:
  - `setLanguage()` 호출 시 Chrome storage 저장
  - 인증된 사용자의 경우 백엔드 API 자동 호출
  - API 호출 실패 시에도 로컬 변경사항 유지 (graceful degradation)

## 테스트
- [x] 빌드 확인
- [x] 주요 기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language preferences now automatically synchronize to your account when changed, ensuring your language selection remains consistent across all sessions and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->